### PR TITLE
feat: 다이얼로그 컨텐츠 조작을 위한 콜백 추가

### DIFF
--- a/app/src/main/java/com/naccoro/wask/customview/waskdialog/WaskDialog.java
+++ b/app/src/main/java/com/naccoro/wask/customview/waskdialog/WaskDialog.java
@@ -44,13 +44,15 @@ public class WaskDialog extends DialogFragment {
     private LinearLayout linearLayoutDialogButtons;
 
     private View contentView;
+    private ContentViewCallback contentCallback;
 
-    public WaskDialog(String title, String message, @LayoutRes int contentRes, List<WaskDialogButton> verticalButtons,
+    public WaskDialog(String title, String message, @LayoutRes int contentRes, ContentViewCallback contentCallback, List<WaskDialogButton> verticalButtons,
                       List<WaskDialogButton> horizontalButtons) {
         super();
         this.title = title;
         this.message = message;
         this.contentRes = contentRes;
+        this.contentCallback = contentCallback;
         this.verticalButtons = verticalButtons;
         this.horizontalButtons = horizontalButtons;
     }
@@ -95,6 +97,11 @@ public class WaskDialog extends DialogFragment {
         //컨텐츠 적용
         if (contentRes != -1) {
             contentView = inflater.inflate(contentRes, linearLayoutDialogContent);
+
+            //컨텐츠에 대한 콜백이 있다면 실행
+            if (contentCallback != null) {
+                contentCallback.onContentViewAttached(contentView);
+            }
         } else { //컨텐츠가 없다면 약간의 마진을 줌
             ((ConstraintLayout.LayoutParams) linearLayoutDialogContent.getLayoutParams())
                     .setMargins(0, (int) MetricsUtil.convertDpToPixel(19, getContext()), 0, 0);
@@ -179,5 +186,13 @@ public class WaskDialog extends DialogFragment {
 
     public interface OnClickListener {
         void onClick(WaskDialog dialog, View view);
+    }
+
+    /**
+     * 컨텐츠가 다이얼로그에 연결되고 실행되는 콜백을 정의하는 인터페이스
+     * 연결된 컨텐츠를 inflate한 View를 파라미터로 가짐.
+     */
+    public interface ContentViewCallback {
+        void onContentViewAttached(View view);
     }
 }

--- a/app/src/main/java/com/naccoro/wask/customview/waskdialog/WaskDialogBuilder.java
+++ b/app/src/main/java/com/naccoro/wask/customview/waskdialog/WaskDialogBuilder.java
@@ -16,6 +16,7 @@ public class WaskDialogBuilder {
     private String title;
     private String message;
     private int contentRes = -1;
+    private WaskDialog.ContentViewCallback contentCallback;
     private List<WaskDialogButton> verticalButtons;
     private List<WaskDialogButton> horizontalButtons;
 
@@ -24,7 +25,7 @@ public class WaskDialogBuilder {
      * @return 옵션이 적용된 WaskDialog 객체
      */
     public WaskDialog build() {
-        return new WaskDialog(title, message, contentRes, verticalButtons, horizontalButtons);
+        return new WaskDialog(title, message, contentRes, contentCallback, verticalButtons, horizontalButtons);
     }
 
     /**
@@ -57,6 +58,16 @@ public class WaskDialogBuilder {
      */
     public WaskDialogBuilder setContent(@LayoutRes int contentRes) {
         this.contentRes = contentRes;
+        return this;
+    }
+
+    /**
+     * 다이얼로그에 적용된 컨텐츠를 조작하기 위한 콜백 설정
+     * @param callback 컨텐츠가 다이얼로그에 연결되면서 실행될 콜백
+     * @return 메서드 체이닝을 위한 자기 자신을 리턴
+     */
+    public WaskDialogBuilder setContentCallback(WaskDialog.ContentViewCallback callback) {
+        this.contentCallback = callback;
         return this;
     }
 


### PR DESCRIPTION
Resolves: #31

### 변경된 점
- `ContentViewCalback` 인터페이스가 추가되었습니다.
    - `onContentViewAttached(View view)` 메서드를 통해 컨텐츠에 대한 조작을 할 수 있습니다.
```
public interface ContentViewCallback {
    void onContentViewAttached(View view);
}
```
### 예시 코드
#### 컨텐츠로 사용할 테스트 레이아웃
```
<?xml version="1.0" encoding="utf-8"?>
<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
    android:layout_width="match_parent"
    android:layout_height="match_parent"
    xmlns:app="http://schemas.android.com/apk/res-auto">

    <TextView
        android:id="@+id/textview_main_test"
        android:layout_width="match_parent"
        android:layout_height="wrap_content"
        android:background="@color/colorPrimary"
        android:gravity="center"
        android:layout_marginVertical="20dp"
        app:layout_constraintStart_toStartOf="parent"
        app:layout_constraintTop_toTopOf="parent"
        app:layout_constraintEnd_toEndOf="parent"
        app:layout_constraintBottom_toBottomOf="parent"/>

</androidx.constraintlayout.widget.ConstraintLayout>
```

#### 적용 과정에서 텍스트 변경하기
```
new WaskDialogBuilder()
        .setTitle("테스트")
        .setContent(R.layout.test)
        .setContentCallback(view -> {
        TextView textView = view.findViewById(R.id.textview_main_test);
        textView.setText("성공 !");
        })
        .addHorizontalButton("확인", (dialog, view) -> dialog.dismiss())
        .build()
        .show(getSupportFragmentManager(), "test");
```