### PR TITLE
fix: 액티비티 종료시 전환효과 수정

### DIFF
--- a/app/src/main/java/com/naccoro/wask/setting/SettingActivity.java
+++ b/app/src/main/java/com/naccoro/wask/setting/SettingActivity.java
@@ -160,6 +160,11 @@ public class SettingActivity extends AppCompatActivity
     @Override
     public void finishSettingView() {
         finish();
+    }
+
+    @Override
+    public void finish() {
+        super.finish();
         overridePendingTransition(R.anim.slide_activity_fadein, R.anim.slide_activity_fadeout);
     }
 


### PR DESCRIPTION
액티비지 전환 효과가 '뒤로가기'버튼(좌상단)에서는 잘 작동하지만
핸드폰 자체의 '뒤로가기'를 이용하면 적용되지 않았던 문제 해결

Resolve: #38