### PR TITLE
Feature/setting wheel init

### DIFF
--- a/app/src/main/java/com/naccoro/wask/customview/datepicker/wheel/WheelDatePicker.java
+++ b/app/src/main/java/com/naccoro/wask/customview/datepicker/wheel/WheelDatePicker.java
@@ -141,12 +141,7 @@ public class WheelDatePicker extends NestedScrollView implements WheelSnapScroll
 
         WheelRecyclerView wheelRecyclerView = (WheelRecyclerView) recyclerView;
 
-        wheelRecyclerView.post(new Runnable() {
-            @Override
-            public void run() {
-                wheelRecyclerView.adapter.setCenterPosition(position);
-            }
-        });
+        wheelRecyclerView.setCenterPosition(position);
 
         switch (wheelRecyclerView.recyclerViewType) {
             case YEAR:
@@ -170,7 +165,7 @@ public class WheelDatePicker extends NestedScrollView implements WheelSnapScroll
         if (dayRecyclerView.endDateValue != endValue) {
             dayRecyclerView.setRecyclerViewRange(1, endValue);
 
-            int centerPosition = dayRecyclerView.adapter.centerPosition;
+            int centerPosition = dayRecyclerView.getCenterPosition();
             if (centerPosition > endValue) {
 
                 int dayInitPosition = 0;
@@ -180,23 +175,23 @@ public class WheelDatePicker extends NestedScrollView implements WheelSnapScroll
     }
 
     public int getYear() {
-        return yearRecyclerView.adapter.getDate();
+        return yearRecyclerView.getWheelValue();
     }
 
     public int getMonth() {
-        return monthRecyclerView.adapter.getDate() - 1;
+        return monthRecyclerView.getWheelValue() - 1;
     }
 
     public int getDay() {
-        return dayRecyclerView.adapter.getDate();
+        return dayRecyclerView.getWheelValue();
     }
 
     /**
      * DatePicker의 달력 초기 값을 설정하는 함수
      *
-     * @param year : 년도
+     * @param year  : 년도
      * @param month : 월  Calendar 객체 특성상 month 0은 1월을 의미
-     * @param day : 일자
+     * @param day   : 일자
      */
     public void setDate(int year, int month, int day) {
 

--- a/app/src/main/java/com/naccoro/wask/customview/datepicker/wheel/WheelDatePicker.java
+++ b/app/src/main/java/com/naccoro/wask/customview/datepicker/wheel/WheelDatePicker.java
@@ -141,7 +141,12 @@ public class WheelDatePicker extends NestedScrollView implements WheelSnapScroll
 
         WheelRecyclerView wheelRecyclerView = (WheelRecyclerView) recyclerView;
 
-        wheelRecyclerView.adapter.setCenterPosition(position);
+        wheelRecyclerView.post(new Runnable() {
+            @Override
+            public void run() {
+                wheelRecyclerView.adapter.setCenterPosition(position);
+            }
+        });
 
         switch (wheelRecyclerView.recyclerViewType) {
             case YEAR:

--- a/app/src/main/java/com/naccoro/wask/customview/datepicker/wheel/WheelDatePicker.java
+++ b/app/src/main/java/com/naccoro/wask/customview/datepicker/wheel/WheelDatePicker.java
@@ -3,7 +3,6 @@ package com.naccoro.wask.customview.datepicker.wheel;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Paint;
-import android.os.Handler;
 import android.util.AttributeSet;
 import android.view.Gravity;
 import android.view.ViewGroup;
@@ -11,7 +10,6 @@ import android.widget.LinearLayout;
 
 import androidx.annotation.Nullable;
 import androidx.core.widget.NestedScrollView;
-import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.LinearSnapHelper;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -34,8 +32,6 @@ import java.util.GregorianCalendar;
  * 한 레이아웃에서 3개의 RecyclerView 스크롤을 인식하기 위해 NestedScrollView를 사용합니다.
  */
 public class WheelDatePicker extends NestedScrollView implements WheelSnapScrollListener.OnSnapPositionChangeListener {
-
-    boolean isDateInitDone = true;
 
     private WheelRecyclerView yearRecyclerView;
     private WheelRecyclerView monthRecyclerView;
@@ -80,12 +76,8 @@ public class WheelDatePicker extends NestedScrollView implements WheelSnapScroll
         this.addView(parent, rootParams);
 
         yearRecyclerView = new WheelRecyclerView(context);
-        //사용자가 RecyclerView의 뷰 끝에서 스크롤을 시도할 시 번지는 효과 제거
-        yearRecyclerView.setOverScrollMode(OVER_SCROLL_NEVER);
         monthRecyclerView = new WheelRecyclerView(context);
-        monthRecyclerView.setOverScrollMode(OVER_SCROLL_NEVER);
         dayRecyclerView = new WheelRecyclerView(context);
-        dayRecyclerView.setOverScrollMode(OVER_SCROLL_NEVER);
 
         recyclerHeight = yearRecyclerView.getMaxHeight();
 
@@ -147,156 +139,69 @@ public class WheelDatePicker extends NestedScrollView implements WheelSnapScroll
             return;
         }
 
-        final WheelRecyclerView wheelRecyclerView = (WheelRecyclerView) recyclerView;
-        wheelRecyclerView.post(new Runnable() {
-            @Override
-            public void run() {
-                wheelRecyclerView.adapter.setCenterPosition(position);
-            }
-        });
+        WheelRecyclerView wheelRecyclerView = (WheelRecyclerView) recyclerView;
+
+        wheelRecyclerView.adapter.setCenterPosition(position);
 
         switch (wheelRecyclerView.recyclerViewType) {
             case YEAR:
             case MONTH:
-                if (isDateInitDone) {
-                    setRangeDay(true);
-                }
+                setRangeDay();
                 break;
-            case DAY:
-                if (!isDateInitDone) {
-                    setAllSnapListenerScroll();
-                    isDateInitDone = true;
-                }
         }
     }
 
     /**
      * dayRecyclerView의 범위를 설정한다. (1일 ~ 31일, 1일 ~ 29일)
-     *
-     * @param scrollTo : 범위를 설정하고 스크롤 할지를 묻는 변수
      */
-    private void setRangeDay(final boolean scrollTo) {
+    private void setRangeDay() {
         int year = getYear();
         int month = getMonth();
 
-        final Calendar calendar = new GregorianCalendar(year, month, 1);
+        Calendar calendar = new GregorianCalendar(year, month, 1);
 
-        new Handler().postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                //해당일자 년 달력의 마지막 요일을 계산
-                int endValue = calendar.getActualMaximum(Calendar.DAY_OF_MONTH);
-                //마지막 일이 변경될 경우 RecyclerView 범위 초기화
-                if (dayRecyclerView.endDateValue != endValue) {
-                    dayRecyclerView.setRecyclerViewRange(1, endValue);
+        int endValue = calendar.getActualMaximum(Calendar.DAY_OF_MONTH);
+        //마지막 일이 변경될 경우 RecyclerView 범위 초기화
+        if (dayRecyclerView.endDateValue != endValue) {
+            dayRecyclerView.setRecyclerViewRange(1, endValue);
 
-                    int centerPosition = dayRecyclerView.adapter.centerPosition;
-                    if (scrollTo && centerPosition > endValue) {
+            int centerPosition = dayRecyclerView.adapter.centerPosition;
+            if (centerPosition > endValue) {
 
-                        int dayInitPosition = 0;
-
-                        LinearLayoutManager manager = (LinearLayoutManager) dayRecyclerView.getLayoutManager();
-                        if (manager != null) {
-                            dayRecyclerView.adapter.setCenterPosition(dayRecyclerView.adapter.getEmptySpace());
-                            manager.scrollToPositionWithOffset(dayInitPosition, 0);
-                        }
-                    }
-                }
+                int dayInitPosition = 0;
+                dayRecyclerView.setInitPosition(dayInitPosition);
             }
-        }, 200);
+        }
     }
 
     public int getYear() {
-        int year = yearRecyclerView.adapter.getDate();
-        return year;
+        return yearRecyclerView.adapter.getDate();
     }
 
     public int getMonth() {
-        int month = monthRecyclerView.adapter.getDate() - 1;
-        return month;
+        return monthRecyclerView.adapter.getDate() - 1;
     }
 
     public int getDay() {
-        int day = dayRecyclerView.adapter.getDate();
-        return day;
+        return dayRecyclerView.adapter.getDate();
     }
 
     /**
      * DatePicker의 달력 초기 값을 설정하는 함수
      *
-     * @param year
-     * @param month
-     * @param day
+     * @param year : 년도
+     * @param month : 월  Calendar 객체 특성상 month 0은 1월을 의미
+     * @param day : 일자
      */
     public void setDate(int year, int month, int day) {
 
-        setAllSnapListenerScrollIdle();
-        isDateInitDone = false;
+        yearRecyclerView.setInitPosition(year);
 
-        new Handler().postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                final int yearPosition = (year - WheelRecyclerView.START_YEAR_VALUE);
-                LinearLayoutManager manager = (LinearLayoutManager) yearRecyclerView.getLayoutManager();
-                if (manager != null) {
-                    //기존 RecyclerView.smoothScrollToPosition or scrollToPosition은 잘못된 스크롤 동작 방식이 여러 보고 되었다.
-                    //정확한 위치로 이동하기 위해서는 LayoutManager를 사용해야한다.
-                    yearRecyclerView.adapter.setCenterPosition(yearPosition + yearRecyclerView.adapter.getEmptySpace());
-                    manager.scrollToPositionWithOffset(yearPosition, 0);
-                }
-            }
-        }, 200);
+        monthRecyclerView.setInitPosition(month + 1);
 
-        new Handler().postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                final int monthPosition = month;
-                LinearLayoutManager manager = (LinearLayoutManager) monthRecyclerView.getLayoutManager();
-                if (manager != null) {
-                    monthRecyclerView.adapter.setCenterPosition(monthPosition + monthRecyclerView.adapter.getEmptySpace());
-                    manager.scrollToPositionWithOffset(monthPosition, 0);
-                }
-            }
-        }, 400);
+        //변경된 년도와 월로 Day Range 설정
+        setRangeDay();
 
-        new Handler().postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                //변경된 년도 달력에 따라 마지막 요일 적용
-                setRangeDay(false);
-                final int dayPosition = day - 1;
-                LinearLayoutManager manager = (LinearLayoutManager) dayRecyclerView.getLayoutManager();
-                if (manager != null) {
-                    dayRecyclerView.adapter.setCenterPosition(dayPosition + dayRecyclerView.adapter.getEmptySpace());
-                    manager.scrollToPositionWithOffset(dayPosition, 0);
-                }
-            }
-        }, 600);
+        dayRecyclerView.setInitPosition(day);
     }
-
-    private void setAllSnapListenerScrollIdle() {
-        //year, month, day 모두 snap Listener 적용
-        yearRecyclerView.setSnapBehaviorType(
-                WheelSnapScrollListener.Behavior.NOTIFY_ON_SCROLL_STATE_IDLE);
-
-        monthRecyclerView.setSnapBehaviorType(
-                WheelSnapScrollListener.Behavior.NOTIFY_ON_SCROLL_STATE_IDLE);
-
-        dayRecyclerView.setSnapBehaviorType(
-                WheelSnapScrollListener.Behavior.NOTIFY_ON_SCROLL_STATE_IDLE);
-    }
-
-    private void setAllSnapListenerScroll() {
-        //year, month, day 모두 snap Listener 적용
-        yearRecyclerView.setSnapBehaviorType(
-                WheelSnapScrollListener.Behavior.NOTIFY_ON_SCROLL);
-
-        monthRecyclerView.setSnapBehaviorType(
-                WheelSnapScrollListener.Behavior.NOTIFY_ON_SCROLL);
-
-        dayRecyclerView.setSnapBehaviorType(
-                WheelSnapScrollListener.Behavior.NOTIFY_ON_SCROLL);
-    }
-
-
 }

--- a/app/src/main/java/com/naccoro/wask/customview/datepicker/wheel/WheelRecyclerView.java
+++ b/app/src/main/java/com/naccoro/wask/customview/datepicker/wheel/WheelRecyclerView.java
@@ -1,6 +1,7 @@
 package com.naccoro.wask.customview.datepicker.wheel;
 
 import android.content.Context;
+import android.os.Handler;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.util.TypedValue;
@@ -84,6 +85,8 @@ public class WheelRecyclerView extends RecyclerView implements WheelSnapScrollLi
     private void init(Context context) {
         this.context = context;
         this.setItemAnimator(null);
+        //사용자가 RecyclerView의 뷰 끝에서 스크롤을 시도할 시 번지는 효과 제거
+        this.setOverScrollMode(OVER_SCROLL_NEVER);
 
         LinearLayoutManager manager = new LinearLayoutManager(context);
         this.setLayoutManager(manager);
@@ -120,11 +123,6 @@ public class WheelRecyclerView extends RecyclerView implements WheelSnapScrollLi
         this.addOnScrollListener(wheelSnapScrollListener);
     }
 
-    public void setSnapBehaviorType(WheelSnapScrollListener.Behavior behaviorType) {
-        if (wheelSnapScrollListener != null) {
-            wheelSnapScrollListener.behavior = behaviorType;
-        }
-    }
 
     public void setRecyclerViewType(WheelRecyclerViewType type) {
         recyclerViewType = type;
@@ -185,6 +183,20 @@ public class WheelRecyclerView extends RecyclerView implements WheelSnapScrollLi
         allItemHeight += getSecondLabelHeight() * 2;
 
         return allItemHeight;
+    }
+
+    /**
+     * 초기 Position 설정
+     * @param position init position
+     */
+    public void setInitPosition(int position) {
+
+        int initPosition = position - startDateValue;
+        LinearLayoutManager manager = (LinearLayoutManager)WheelRecyclerView.this.getLayoutManager();
+        if (manager != null) {
+            WheelRecyclerView.this.adapter.setCenterPosition(initPosition + WheelRecyclerView.this.adapter.getEmptySpace());
+            manager.scrollToPositionWithOffset(initPosition, 0);
+        }
     }
 
     /**

--- a/app/src/main/java/com/naccoro/wask/customview/datepicker/wheel/WheelRecyclerView.java
+++ b/app/src/main/java/com/naccoro/wask/customview/datepicker/wheel/WheelRecyclerView.java
@@ -283,12 +283,7 @@ public class WheelRecyclerView extends RecyclerView implements WheelSnapScrollLi
 
     @Override
     public void onSnapPositionChange(RecyclerView recyclerView, int position) {
-        WheelRecyclerView.this.post(new Runnable() {
-            @Override
-            public void run() {
-                WheelRecyclerView.this.adapter.setCenterPosition(position);
-            }
-        });
+        WheelRecyclerView.this.setCenterPosition(position);
     }
 
     /**

--- a/app/src/main/java/com/naccoro/wask/customview/datepicker/wheel/WheelRecyclerView.java
+++ b/app/src/main/java/com/naccoro/wask/customview/datepicker/wheel/WheelRecyclerView.java
@@ -268,7 +268,12 @@ public class WheelRecyclerView extends RecyclerView implements WheelSnapScrollLi
 
     @Override
     public void onSnapPositionChange(RecyclerView recyclerView, int position) {
-        this.adapter.setCenterPosition(position);
+        WheelRecyclerView.this.post(new Runnable() {
+            @Override
+            public void run() {
+                WheelRecyclerView.this.adapter.setCenterPosition(position);
+            }
+        });
     }
 
     /**

--- a/app/src/main/java/com/naccoro/wask/customview/datepicker/wheel/WheelRecyclerView.java
+++ b/app/src/main/java/com/naccoro/wask/customview/datepicker/wheel/WheelRecyclerView.java
@@ -59,7 +59,7 @@ public class WheelRecyclerView extends RecyclerView implements WheelSnapScrollLi
 
     private WheelSnapScrollListener wheelSnapScrollListener;
     private Context context;
-    WheelRecyclerAdapter adapter;
+    private WheelRecyclerAdapter adapter;
     WheelRecyclerViewType recyclerViewType = DEFAULT_TYPE;
 
     //이 RecyclerView가 보여주는 범위를 저장한다.
@@ -186,26 +186,41 @@ public class WheelRecyclerView extends RecyclerView implements WheelSnapScrollLi
     }
 
     /**
-     * 초기 Position 설정
+     * 초기 RecyclerView Position 설정
+     *
      * @param position init position
      */
     public void setInitPosition(int position) {
 
         int initPosition = position - startDateValue;
-        LinearLayoutManager manager = (LinearLayoutManager)WheelRecyclerView.this.getLayoutManager();
+        LinearLayoutManager manager = (LinearLayoutManager) WheelRecyclerView.this.getLayoutManager();
         if (manager != null) {
-            WheelRecyclerView.this.adapter.setCenterPosition(initPosition + WheelRecyclerView.this.adapter.getEmptySpace());
+            WheelRecyclerView.this.setCenterPosition(initPosition + WheelRecyclerView.this.adapter.getEmptySpace());
             manager.scrollToPositionWithOffset(initPosition, 0);
         }
     }
 
+    public void setCenterPosition(int position) {
+        WheelRecyclerView.this.post(new Runnable() {
+            @Override
+            public void run() {
+                WheelRecyclerView.this.adapter.setCenterPosition(position);
+            }
+        });
+    }
+
+    public int getCenterPosition() {
+        return WheelRecyclerView.this.adapter.centerPosition;
+    }
+
+
     /**
-     * 현재 사용자의 스크롤에 의해서 가운데에 보이는 값을 가져옴
+     * 범위와 centerPosition, 빈공간을 고려하여 의미하고 있는 Data 값을 반환한다.
      *
-     * @return 가운데에 있는 값
+     * @return 빈공간을 계산하여 구한 날짜 값
      */
-    public int getSnapValue() {
-        return adapter.getDate();
+    public int getWheelValue() {
+        return startDateValue + (adapter.centerPosition - adapter.emptySpace);
     }
 
     public float getSelectedLabelHeight() {
@@ -302,7 +317,8 @@ public class WheelRecyclerView extends RecyclerView implements WheelSnapScrollLi
         }
 
         /**
-         *  type이 None이 아닐 경우 emptySpace를 2로 설정한다. 보여주어야 하는 Item이 5개 이기 때문.
+         * type이 None이 아닐 경우 emptySpace를 2로 설정한다. 보여주어야 하는 Item이 5개 이기 때문.
+         *
          * @param type : year, month, day, none
          */
         public void setRecyclerType(WheelRecyclerViewType type) {
@@ -383,15 +399,6 @@ public class WheelRecyclerView extends RecyclerView implements WheelSnapScrollLi
         @Override
         public int getItemCount() {
             return (endDateValue - startDateValue + 1) + emptySpace * 2;
-        }
-
-        /**
-         * 범위로 centerPosition 그 자체가 날짜 데이터가 될 수 있다.
-         *
-         * @return 빈공간을 계산하여 구한 날짜 값
-         */
-        public int getDate() {
-            return startDateValue + (centerPosition - emptySpace);
         }
 
         private String getDateString(int position) {

--- a/app/src/main/java/com/naccoro/wask/setting/SettingActivity.java
+++ b/app/src/main/java/com/naccoro/wask/setting/SettingActivity.java
@@ -99,7 +99,7 @@ public class SettingActivity extends AppCompatActivity
                 .addHorizontalButton(getString(R.string.setting_dialog_ok), (dialog, view) -> {
                     //이후 wheelPicker value로 대체
                     WheelRecyclerView wheelRecyclerView = view.findViewById(R.id.wheelrecycler_replacementcycle);
-                    presenter.changeReplacementCycleValue(wheelRecyclerView.getSnapValue());
+                    presenter.changeReplacementCycleValue(wheelRecyclerView.getWheelValue());
                     dialog.dismiss();
                 })
                 .build()
@@ -122,7 +122,7 @@ public class SettingActivity extends AppCompatActivity
                 .addHorizontalButton(getString(R.string.setting_dialog_ok), (dialog, view) -> {
                     //이후 wheelPicker value로 대체
                     WheelRecyclerView wheelRecyclerView = view.findViewById(R.id.wheelrecycler_replacelater);
-                    presenter.changeReplaceLaterValue(wheelRecyclerView.getSnapValue());
+                    presenter.changeReplaceLaterValue(wheelRecyclerView.getWheelValue());
                     dialog.dismiss();
                 })
                 .build()

--- a/app/src/main/java/com/naccoro/wask/setting/SettingActivity.java
+++ b/app/src/main/java/com/naccoro/wask/setting/SettingActivity.java
@@ -15,6 +15,7 @@ import android.widget.TextView;
 import com.naccoro.wask.R;
 import com.naccoro.wask.customview.datepicker.DatePickerDialogFragment;
 import com.naccoro.wask.customview.datepicker.wheel.WheelRecyclerView;
+import com.naccoro.wask.customview.waskdialog.WaskDialog;
 import com.naccoro.wask.customview.waskdialog.WaskDialogBuilder;
 
 public class SettingActivity extends AppCompatActivity
@@ -31,6 +32,9 @@ public class SettingActivity extends AppCompatActivity
 
     private SettingPresenter presenter;
 
+    private int periodReplacementCycle;
+
+    private int periodReplaceLater;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -87,6 +91,13 @@ public class SettingActivity extends AppCompatActivity
         new WaskDialogBuilder()
                 .setTitle(getString(R.string.setting_replacement_cycle))
                 .setContent(R.layout.dialog_replacementcycle)
+                .setContentCallback(new WaskDialog.ContentViewCallback() {
+                    @Override
+                    public void onContentViewAttached(View view) {
+                        WheelRecyclerView wheelRecyclerView = view.findViewById(R.id.wheelrecycler_replacementcycle);
+                        wheelRecyclerView.setInitPosition(periodReplacementCycle);
+                    }
+                })
                 .addHorizontalButton(getString(R.string.setting_dialog_ok), (dialog, view) -> {
                     //이후 wheelPicker value로 대체
                     WheelRecyclerView wheelRecyclerView = view.findViewById(R.id.wheelrecycler_replacementcycle);
@@ -103,6 +114,13 @@ public class SettingActivity extends AppCompatActivity
         new WaskDialogBuilder()
                 .setTitle(getString(R.string.setting_replace_later))
                 .setContent(R.layout.dialog_replacelater)
+                .setContentCallback(new WaskDialog.ContentViewCallback() {
+                    @Override
+                    public void onContentViewAttached(View view) {
+                        WheelRecyclerView wheelRecyclerView = view.findViewById(R.id.wheelrecycler_replacelater);
+                        wheelRecyclerView.setInitPosition(periodReplaceLater);
+                    }
+                })
                 .addHorizontalButton(getString(R.string.setting_dialog_ok), (dialog, view) -> {
                     //이후 wheelPicker value로 대체
                     WheelRecyclerView wheelRecyclerView = view.findViewById(R.id.wheelrecycler_replacelater);
@@ -139,11 +157,13 @@ public class SettingActivity extends AppCompatActivity
 
     @Override
     public void showReplacementCycleValue(int cycleValue) {
+        periodReplacementCycle = cycleValue;
         replacementCycleAlertLabel.setText(cycleValue + "일");
     }
 
     @Override
     public void showReplaceLaterValue(int laterValue) {
+        periodReplaceLater = laterValue;
         replaceLaterLabel.setText(laterValue + "일");
     }
 


### PR DESCRIPTION
### #8 Setting Activity 구현
---
**구현한 점**
  -  `ReplacementCycle`과 `ReplaceLater Dialog` 초기 값이 사용자가 최종으로 설정한 주기값으로 설정되었습니다.
 
  -  SettingActivity 관련 commit이 꼬였는 지, 이번에도 전부 변경 사항으로 등록되었습니다..

### #1 datePicker 
---
**수정한 점**
  -  `wheelRecyclerView` 초기값을 설정하는 `setInitPosition`을 만들어져서  기존 `WheelDatePicker.setDate()` 함수 내용 중 수정

      -  이번 PR에서 `LayoutManager.scrollToPositionWithOffset()` 호출은 `Handler.postDelyed()`의 지연 없이 정확한 위치로 이동하는 것을 확인했습니다.

       ```java
           /**
           * 초기 RecyclerView Position 설정
           *
           * @param position init position
           */
           public void setInitPosition(int position) {

                 int initPosition = position - startDateValue;
                 LinearLayoutManager manager = (LinearLayoutManager) WheelRecyclerView.this.getLayoutManager();
                 if (manager != null) {
                 WheelRecyclerView.this.setCenterPosition(initPosition + WheelRecyclerView.this.adapter.getEmptySpace());
                  manager.scrollToPositionWithOffset(initPosition, 0);
              }
          }
       ```

      -  `LayoutManager.scrollToPositionWithOffset()`을 사용한 recyclerView 초기 position 값 세팅은 `Scroll Listener`를 호출시키지 않다는 것을 알게 되었습니다.
            - 기존에는 Scroll Listener가 과도하게 호출 될 줄 알고 Snap Listener가 스크롤이 멈출 때 호출되도록 로직을 구현했던 부분을 삭제했습니다.

 -  SettingActivity 기능에서 `WheelRecycler`가 독립적으로 사용되므로 `WheelAdaper`를 직접 접근할 수 있는 부분이 객체지향적이지 않다고 생각하여 수정했습니다.

**버그 수정**

 - 기존 RecyclerVIew가 스크롤이 될 때마다 호출되는 SnapScrollListener에서 화면의 UI를 변경하는 코드가 사용되어서 앱이 강제종료 되지는 않지만 Exception이 Log창에 나오는 Error 수정

     -  `View.post()`를 사용해 UIThread에서 수정되도록 사용

     ```java
       public void setCenterPosition(int position) {
        WheelRecyclerView.this.post(new Runnable() {
            @Override
            public void run() {
                WheelRecyclerView.this.adapter.setCenterPosition(position);
            }
        });
    }
     ```