### PR TITLE
Feature/replace mask

### DIFF
--- a/app/src/main/java/com/naccoro/wask/main/MainActivity.java
+++ b/app/src/main/java/com/naccoro/wask/main/MainActivity.java
@@ -1,7 +1,6 @@
 package com.naccoro.wask.main;
 
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.content.ContextCompat;
 
 import android.content.Intent;
 import android.os.Bundle;
@@ -12,7 +11,6 @@ import android.widget.Toast;
 
 import com.naccoro.wask.R;
 import com.naccoro.wask.calendar.CalendarActivity;
-import com.naccoro.wask.customview.waskdialog.WaskDialog;
 import com.naccoro.wask.customview.waskdialog.WaskDialogBuilder;
 import com.naccoro.wask.replacement.model.Injection;
 import com.naccoro.wask.setting.SettingActivity;
@@ -26,6 +24,7 @@ public class MainActivity extends AppCompatActivity
     ImageView emotionImageView;
     TextView cardMessageTextView;
     TextView usePeriodTextView;
+    TextView usePeriodMessageTextView;
     TextView changeButton;
 
     @Override
@@ -48,6 +47,7 @@ public class MainActivity extends AppCompatActivity
         emotionImageView = findViewById(R.id.imageview_emotion);
         cardMessageTextView = findViewById(R.id.textview_card_message);
         usePeriodTextView = findViewById(R.id.textview_use_period);
+        usePeriodMessageTextView = findViewById(R.id.textview_use_period_message);
         changeButton = findViewById(R.id.button_change);
 
         settingButton.setOnClickListener(this);
@@ -143,8 +143,7 @@ public class MainActivity extends AppCompatActivity
     @Override
     public void showCancelDialog() {
         new WaskDialogBuilder()
-                .setTitle("교체 취소")
-                .setMessage("정말 교체하기를 취소하겠습니까?")
+                .setMessage(getString(R.string.dialog_cancelreplacement))
                 .addHorizontalButton("취소", (dialog, view) -> dialog.dismiss())
                 .addHorizontalButton("확인", ((dialog, view) -> {
                     presenter.cancelChanging();
@@ -152,5 +151,17 @@ public class MainActivity extends AppCompatActivity
                 }))
                 .build()
                 .show(getSupportFragmentManager(), "cancel");
+    }
+
+    @Override
+    public void showNoReplaceData() {
+        usePeriodTextView.setVisibility(View.GONE);
+        usePeriodMessageTextView.setText(R.string.main_use_period_message_no_replacement);
+    }
+
+    @Override
+    public void changeUsePeriodMessage() {
+        usePeriodTextView.setVisibility(View.VISIBLE);
+        usePeriodMessageTextView.setText(R.string.main_use_period_message);
     }
 }

--- a/app/src/main/java/com/naccoro/wask/main/MainActivity.java
+++ b/app/src/main/java/com/naccoro/wask/main/MainActivity.java
@@ -12,6 +12,8 @@ import android.widget.Toast;
 
 import com.naccoro.wask.R;
 import com.naccoro.wask.calendar.CalendarActivity;
+import com.naccoro.wask.customview.waskdialog.WaskDialog;
+import com.naccoro.wask.customview.waskdialog.WaskDialogBuilder;
 import com.naccoro.wask.replacement.model.Injection;
 import com.naccoro.wask.setting.SettingActivity;
 
@@ -65,6 +67,7 @@ public class MainActivity extends AppCompatActivity
                 presenter.clickCalendarButton();
                 break;
             case R.id.button_change:
+                // 교체 로직 실행
                 presenter.changeMask();
                 break;
         }
@@ -76,9 +79,14 @@ public class MainActivity extends AppCompatActivity
     }
 
     @Override
+    public void enableReplaceButton() {
+        changeButton.setText("교체하기");
+        changeButton.setBackgroundTintList(null);
+    }
+
+    @Override
     public void disableReplaceButton() {
-        changeButton.setClickable(false);
-        changeButton.setText("교체 완료");
+        changeButton.setText("교체 취소");
         changeButton.setBackgroundTintList(getResources().getColorStateList(R.color.dividerGray, null));
     }
 
@@ -130,5 +138,19 @@ public class MainActivity extends AppCompatActivity
     @Override
     public void setPeriodTextValue(int period) {
         usePeriodTextView.setText(period + "");
+    }
+
+    @Override
+    public void showCancelDialog() {
+        new WaskDialogBuilder()
+                .setTitle("교체 취소")
+                .setMessage("정말 교체하기를 취소하겠습니까?")
+                .addHorizontalButton("취소", (dialog, view) -> dialog.dismiss())
+                .addHorizontalButton("확인", ((dialog, view) -> {
+                    presenter.cancelChanging();
+                    dialog.dismiss();
+                }))
+                .build()
+                .show(getSupportFragmentManager(), "cancel");
     }
 }

--- a/app/src/main/java/com/naccoro/wask/main/MainActivity.java
+++ b/app/src/main/java/com/naccoro/wask/main/MainActivity.java
@@ -1,6 +1,7 @@
 package com.naccoro.wask.main;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
 
 import android.content.Intent;
 import android.os.Bundle;
@@ -11,6 +12,7 @@ import android.widget.Toast;
 
 import com.naccoro.wask.R;
 import com.naccoro.wask.calendar.CalendarActivity;
+import com.naccoro.wask.replacement.model.Injection;
 import com.naccoro.wask.setting.SettingActivity;
 
 public class MainActivity extends AppCompatActivity
@@ -28,7 +30,7 @@ public class MainActivity extends AppCompatActivity
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-        presenter = new MainPresenter(this);
+        presenter = new MainPresenter(this, Injection.replacementHistoryRepository(getApplicationContext()));
         initView();
     }
 
@@ -58,9 +60,21 @@ public class MainActivity extends AppCompatActivity
                 break;
             case R.id.button_change:
                 // '교체하기' 버튼을 눌렀을 때 (버튼 동작을 확인하기위해 toast메시지를 띄워놓았습니다.)
-                Toast.makeText(this.getApplicationContext(), "교체되었습니다.", Toast.LENGTH_SHORT).show();
+                presenter.clickReplaceButton();
                 break;
         }
+    }
+
+    @Override
+    public void showReplaceToast() {
+        Toast.makeText(this.getApplicationContext(), "교체되었습니다.", Toast.LENGTH_SHORT).show();
+    }
+
+    @Override
+    public void disableReplaceButton() {
+        changeButton.setClickable(false);
+        changeButton.setText("교체 완료");
+        changeButton.setBackgroundTintList(getResources().getColorStateList(R.color.dividerGray, null));
     }
 
     @Override

--- a/app/src/main/java/com/naccoro/wask/main/MainContract.java
+++ b/app/src/main/java/com/naccoro/wask/main/MainContract.java
@@ -20,6 +20,10 @@ public interface MainContract {
         void enableReplaceButton();
 
         void showCancelDialog();
+
+        void showNoReplaceData();
+
+        void changeUsePeriodMessage();
     }
 
     interface Presenter {

--- a/app/src/main/java/com/naccoro/wask/main/MainContract.java
+++ b/app/src/main/java/com/naccoro/wask/main/MainContract.java
@@ -16,6 +16,10 @@ public interface MainContract {
         void showBadMainView();
 
         void setPeriodTextValue(int period);
+
+        void enableReplaceButton();
+
+        void showCancelDialog();
     }
 
     interface Presenter {
@@ -27,6 +31,8 @@ public interface MainContract {
         void clickCalendarButton();
 
         void changeMask();
+
+        void cancelChanging();
     }
 
 }

--- a/app/src/main/java/com/naccoro/wask/main/MainContract.java
+++ b/app/src/main/java/com/naccoro/wask/main/MainContract.java
@@ -5,11 +5,14 @@ public interface MainContract {
     interface View {
         void showSettingView();
         void showCalendarView();
+        void showReplaceToast();
+        void disableReplaceButton();
     }
 
     interface Presenter {
         void clickSettingButton();
         void clickCalendarButton();
+        void clickReplaceButton();
     }
 
 }

--- a/app/src/main/java/com/naccoro/wask/main/MainPresenter.java
+++ b/app/src/main/java/com/naccoro/wask/main/MainPresenter.java
@@ -115,12 +115,12 @@ public class MainPresenter implements MainContract.Presenter {
      * @return [오늘 날짜 - 마지막 교체 일자 + 1]
      */
     private int getMaskPeriod() {
-        String lastReplacement = replacementHistoryRepository.getLastReplacement();
-        if (lastReplacement == null) {
+        int lastReplacement = replacementHistoryRepository.getLastReplacement();
+        if (lastReplacement == -1) {
             //교체 기록이 없을 경우
             isNoData = true;
             return 0;
         }
-        return DateUtils.getTodayToInt() - DateUtils.getDateToInt(lastReplacement) + 1;
+        return DateUtils.getToday() - lastReplacement + 1;
     }
 }

--- a/app/src/main/java/com/naccoro/wask/main/MainPresenter.java
+++ b/app/src/main/java/com/naccoro/wask/main/MainPresenter.java
@@ -28,7 +28,10 @@ public class MainPresenter implements MainContract.Presenter {
         int period = getMaskPeriod();
         mainView.setPeriodTextValue(period);
 
-        if (period > 1) {
+        if (period == 0) {
+            //Todo: 교체 기록이 없을 경우 로직 고안
+            Log.d(TAG, "start: No replacement data");
+        } else if (period > 1) {
             mainView.showBadMainView();
         } else {
             mainView.showGoodMainView();
@@ -56,11 +59,15 @@ public class MainPresenter implements MainContract.Presenter {
     /**
      * WaskDatabase에서 현재 마스크 교체 상태를 가져오는 함수
      *
-     * @return [오늘 날짜 - 마지막 교체 일자]
+     * @return [오늘 날짜 - 마지막 교체 일자 + 1]
      */
     private int getMaskPeriod() {
-        //TODO: WaskDatabase에서 교체일자를 비교하여 현재 상태를 가져온다.
-        return 3;
+        String lastReplacement = replacementHistoryRepository.getLastReplacement();
+        if (lastReplacement == null) {
+            //교체 기록이 없을 경우
+            return 0;
+        }
+        return DateUtils.getTodayToInt() - DateUtils.getDateToInt(replacementHistoryRepository.getLastReplacement()) + 1;
     }
 
     @Override
@@ -98,8 +105,7 @@ public class MainPresenter implements MainContract.Presenter {
 
     @Override
     public void cancelChanging() {
-        isChanged = false;
         replacementHistoryRepository.deleteToday();
-        mainView.enableReplaceButton();
+        start();
     }
 }

--- a/app/src/main/java/com/naccoro/wask/main/MainPresenter.java
+++ b/app/src/main/java/com/naccoro/wask/main/MainPresenter.java
@@ -121,6 +121,6 @@ public class MainPresenter implements MainContract.Presenter {
             isNoData = true;
             return 0;
         }
-        return DateUtils.getToday() - lastReplacement + 1;
+        return DateUtils.calculateDateGapWithToday(lastReplacement) + 1;
     }
 }

--- a/app/src/main/java/com/naccoro/wask/main/MainPresenter.java
+++ b/app/src/main/java/com/naccoro/wask/main/MainPresenter.java
@@ -40,6 +40,9 @@ public class MainPresenter implements MainContract.Presenter {
         setIsChanged();
     }
 
+    /**
+     * 오늘 마스크를 교체하였는지 확인 후 버튼 상태를 변경
+     */
     private void setIsChanged() {
         replacementHistoryRepository.get(DateUtils.getToday(), new ReplacementHistoryRepository.GetHistoriesCallback() {
             @Override
@@ -54,20 +57,6 @@ public class MainPresenter implements MainContract.Presenter {
                 mainView.enableReplaceButton();
             }
         });
-    }
-
-    /**
-     * WaskDatabase에서 현재 마스크 교체 상태를 가져오는 함수
-     *
-     * @return [오늘 날짜 - 마지막 교체 일자 + 1]
-     */
-    private int getMaskPeriod() {
-        String lastReplacement = replacementHistoryRepository.getLastReplacement();
-        if (lastReplacement == null) {
-            //교체 기록이 없을 경우
-            return 0;
-        }
-        return DateUtils.getTodayToInt() - DateUtils.getDateToInt(replacementHistoryRepository.getLastReplacement()) + 1;
     }
 
     @Override
@@ -103,9 +92,26 @@ public class MainPresenter implements MainContract.Presenter {
         }
     }
 
+    /**
+     * 교체 취소 다이얼로그에서 확인을 눌렀을 때 호출되는 함수
+     */
     @Override
     public void cancelChanging() {
         replacementHistoryRepository.deleteToday();
         start();
+    }
+
+    /**
+     * WaskDatabase에서 현재 마스크 교체 상태를 가져오는 함수
+     *
+     * @return [오늘 날짜 - 마지막 교체 일자 + 1]
+     */
+    private int getMaskPeriod() {
+        String lastReplacement = replacementHistoryRepository.getLastReplacement();
+        if (lastReplacement == null) {
+            //교체 기록이 없을 경우
+            return 0;
+        }
+        return DateUtils.getTodayToInt() - DateUtils.getDateToInt(replacementHistoryRepository.getLastReplacement()) + 1;
     }
 }

--- a/app/src/main/java/com/naccoro/wask/main/MainPresenter.java
+++ b/app/src/main/java/com/naccoro/wask/main/MainPresenter.java
@@ -1,10 +1,19 @@
 package com.naccoro.wask.main;
 
+import android.util.Log;
+
+import com.naccoro.wask.replacement.repository.ReplacementHistoryRepository;
+
 public class MainPresenter implements MainContract.Presenter {
+    private static final String TAG = "MainPresenter";
+
+    private ReplacementHistoryRepository replacementHistoryRepository;
+
     MainActivity mainView;
 
-    MainPresenter(MainActivity mainView) {
+    MainPresenter(MainActivity mainView, ReplacementHistoryRepository replacementHistoryRepository) {
         this.mainView = mainView;
+        this.replacementHistoryRepository = replacementHistoryRepository;
     }
 
     @Override
@@ -15,5 +24,21 @@ public class MainPresenter implements MainContract.Presenter {
     @Override
     public void clickCalendarButton() {
         mainView.showCalendarView();
+    }
+
+    @Override
+    public void clickReplaceButton() {
+        replacementHistoryRepository.insertToday(new ReplacementHistoryRepository.InsertHistoryCallback() {
+            @Override
+            public void onSuccess() {
+                mainView.showReplaceToast();
+                mainView.disableReplaceButton();
+            }
+
+            @Override
+            public void onDuplicated() {
+                Log.d(TAG, "onDuplicated: true");
+            }
+        });
     }
 }

--- a/app/src/main/java/com/naccoro/wask/replacement/model/Injection.java
+++ b/app/src/main/java/com/naccoro/wask/replacement/model/Injection.java
@@ -1,0 +1,14 @@
+package com.naccoro.wask.replacement.model;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import com.naccoro.wask.replacement.repository.ReplacementHistoryRepository;
+
+public class Injection {
+
+    public static ReplacementHistoryRepository replacementHistoryRepository(@NonNull Context context) {
+        return new ReplacementHistoryRepository(context);
+    }
+}

--- a/app/src/main/java/com/naccoro/wask/replacement/model/ReplacementHistory.java
+++ b/app/src/main/java/com/naccoro/wask/replacement/model/ReplacementHistory.java
@@ -16,13 +16,13 @@ public class ReplacementHistory {
     private int id;
 
     @ColumnInfo(name = "replace_date")
-    //YYYY-MM-DD 형태의 문자열로 저장
-    private String replacedDate;
+    //YYYYMMDD 형태의 정수로 저장
+    private int replacedDate;
 
     @ColumnInfo(name = "replace_date_month")
     private int monthOfReplaceDate;
 
-    public ReplacementHistory(String replacedDate) {
+    public ReplacementHistory(int replacedDate) {
         this.replacedDate = replacedDate;
         this.monthOfReplaceDate = DateUtils.getMonth(replacedDate);
     }
@@ -31,7 +31,7 @@ public class ReplacementHistory {
         return id;
     }
 
-    public String getReplacedDate() {
+    public int getReplacedDate() {
         return replacedDate;
     }
 
@@ -43,7 +43,7 @@ public class ReplacementHistory {
         this.id = id;
     }
 
-    public void setReplacedDate(String replacedDate) {
+    public void setReplacedDate(int replacedDate) {
         this.replacedDate = replacedDate;
         this.monthOfReplaceDate = DateUtils.getMonth(replacedDate);
     }
@@ -62,7 +62,7 @@ public class ReplacementHistory {
     @Override
     public boolean equals(@Nullable Object obj) {
         if (obj instanceof ReplacementHistory) {
-            return this.replacedDate.equals(((ReplacementHistory) obj).replacedDate);
+            return this.replacedDate == ((ReplacementHistory) obj).replacedDate;
         } else {
             return false;
         }

--- a/app/src/main/java/com/naccoro/wask/replacement/model/ReplacementHistory.java
+++ b/app/src/main/java/com/naccoro/wask/replacement/model/ReplacementHistory.java
@@ -1,6 +1,7 @@
 package com.naccoro.wask.replacement.model;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.room.ColumnInfo;
 import androidx.room.Entity;
 import androidx.room.Index;
@@ -56,5 +57,14 @@ public class ReplacementHistory {
     @Override
     public String toString() {
         return "[id : " + getId() + " date : " + getReplacedDate() + "]";
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        if (obj instanceof ReplacementHistory) {
+            return this.replacedDate.equals(((ReplacementHistory) obj).replacedDate);
+        } else {
+            return false;
+        }
     }
 }

--- a/app/src/main/java/com/naccoro/wask/replacement/model/ReplacementHistory.java
+++ b/app/src/main/java/com/naccoro/wask/replacement/model/ReplacementHistory.java
@@ -3,11 +3,12 @@ package com.naccoro.wask.replacement.model;
 import androidx.annotation.NonNull;
 import androidx.room.ColumnInfo;
 import androidx.room.Entity;
+import androidx.room.Index;
 import androidx.room.PrimaryKey;
 
 import com.naccoro.wask.utils.DateUtils;
 
-@Entity(tableName = "replacement_histories")
+@Entity(tableName = "replacement_histories", indices = {@Index(value = {"replace_date"}, unique = true)})
 public class ReplacementHistory {
     @PrimaryKey(autoGenerate = true)
     @ColumnInfo(name="replacement_histories_id")

--- a/app/src/main/java/com/naccoro/wask/replacement/repository/ReplacementHistoryDao.java
+++ b/app/src/main/java/com/naccoro/wask/replacement/repository/ReplacementHistoryDao.java
@@ -17,11 +17,11 @@ public abstract class ReplacementHistoryDao implements BaseDao<ReplacementHistor
     abstract List<ReplacementHistory> getAll(int month);
 
     @Query("SELECT * FROM replacement_histories WHERE replace_date = :date")
-    abstract ReplacementHistory get(String date);
+    abstract ReplacementHistory get(int date);
 
     @Query("DELETE FROM replacement_histories")
     abstract void deleteAll();
 
     @Query("DELETE FROM replacement_histories WHERE replace_date = :date")
-    abstract void delete(String date);
+    abstract void delete(int date);
 }

--- a/app/src/main/java/com/naccoro/wask/replacement/repository/ReplacementHistoryRepository.java
+++ b/app/src/main/java/com/naccoro/wask/replacement/repository/ReplacementHistoryRepository.java
@@ -31,7 +31,7 @@ public class ReplacementHistoryRepository {
 
     public void getAll(int month, LoadHistoriesCallback callback) {
         checkCache();
-        List<ReplacementHistory> result = getAllFromCached(month);
+        List<ReplacementHistory> result = getAllWithMonthFromCached(month);
         Log.d(TAG, "getAll: " + result.toString());
 
         if (result.isEmpty()) {
@@ -41,9 +41,9 @@ public class ReplacementHistoryRepository {
         }
     }
 
-    public void get(String date, GetHistoriesCallback callback) {
+    public void get(int date, GetHistoriesCallback callback) {
         checkCache();
-        ReplacementHistory result = getAllFromCached(date);
+        ReplacementHistory result = getAllWithDateFromCached(date);
 
         if (result != null) {
             Log.d(TAG, "get: " + result.toString());
@@ -54,16 +54,16 @@ public class ReplacementHistoryRepository {
         }
     }
 
-    public String getLastReplacement() {
+    public int getLastReplacement() {
         checkCache();
 
         if (cachedReplacementHistory.size() == 0) {
-            return null;
+            return -1;
         }
 
         Collections.sort(cachedReplacementHistory, (firstHistory, secondHistory) -> {
-            int firstDate = DateUtils.getDateToInt(firstHistory.getReplacedDate());
-            int secondDate = DateUtils.getDateToInt(secondHistory.getReplacedDate());
+            int firstDate = firstHistory.getReplacedDate();
+            int secondDate = secondHistory.getReplacedDate();
 
             return Integer.compare(firstDate, secondDate);
         });
@@ -88,8 +88,7 @@ public class ReplacementHistoryRepository {
 
     private boolean checkReduplication(ReplacementHistory newReplacementHistory) {
         checkCache();
-        boolean test = cachedReplacementHistory.contains(newReplacementHistory);
-        return test;
+        return cachedReplacementHistory.contains(newReplacementHistory);
     }
 
     private void checkCache() {
@@ -98,7 +97,7 @@ public class ReplacementHistoryRepository {
         }
     }
 
-    public void insert(String date, InsertHistoryCallback callback) {
+    public void insert(int date, InsertHistoryCallback callback) {
         ReplacementHistory newReplacementHistory = new ReplacementHistory(date);
         insert(newReplacementHistory, callback);
     }
@@ -113,7 +112,7 @@ public class ReplacementHistoryRepository {
         cachedReplacementHistory = null;
     }
 
-    public void delete(String date) {
+    public void delete(int date) {
         Log.d(TAG, "delete: " + date);
         dao.delete(date);
         updateHistories();
@@ -145,7 +144,7 @@ public class ReplacementHistoryRepository {
         cacheIsDirty = false;
     }
 
-    private List<ReplacementHistory> getAllFromCached(int month) {
+    private List<ReplacementHistory> getAllWithMonthFromCached(int month) {
         if (month != -1) {
             List<ReplacementHistory> result = new ArrayList<>();
             for (ReplacementHistory history : cachedReplacementHistory) {
@@ -159,9 +158,9 @@ public class ReplacementHistoryRepository {
         }
     }
 
-    private ReplacementHistory getAllFromCached(String date) {
+    private ReplacementHistory getAllWithDateFromCached(int date) {
         for (ReplacementHistory history : cachedReplacementHistory) {
-            if (history.getReplacedDate().equals(date)) {
+            if (history.getReplacedDate() == date) {
                 return history;
             }
         }

--- a/app/src/main/java/com/naccoro/wask/replacement/repository/ReplacementHistoryRepository.java
+++ b/app/src/main/java/com/naccoro/wask/replacement/repository/ReplacementHistoryRepository.java
@@ -54,14 +54,13 @@ public class ReplacementHistoryRepository {
     }
     
     public void insert(ReplacementHistory newReplacementHistory, InsertHistoryCallback callback) {
-        Log.d(TAG, "insert: " + newReplacementHistory.toString());
-
         if (checkReduplication(newReplacementHistory) && callback != null) {
             callback.onDuplicated();
             return;
         }
 
         dao.insert(newReplacementHistory);
+        Log.d(TAG, "insert: " + newReplacementHistory.toString());
 
         if (callback != null) {
             callback.onSuccess();
@@ -71,7 +70,8 @@ public class ReplacementHistoryRepository {
 
     private boolean checkReduplication(ReplacementHistory newReplacementHistory) {
         checkCache();
-        return cachedReplacementHistory.contains(newReplacementHistory);
+        boolean test = cachedReplacementHistory.contains(newReplacementHistory);
+        return test;
     }
 
     private void checkCache() {
@@ -105,6 +105,10 @@ public class ReplacementHistoryRepository {
         Log.d(TAG, "deleteAll: delete all of record");
         dao.deleteAll();
         updateHistories();
+    }
+
+    public void deleteToday() {
+        delete(DateUtils.getToday());
     }
 
     public void update(ReplacementHistory updatedReplacementHistory) {

--- a/app/src/main/java/com/naccoro/wask/replacement/repository/ReplacementHistoryRepository.java
+++ b/app/src/main/java/com/naccoro/wask/replacement/repository/ReplacementHistoryRepository.java
@@ -9,7 +9,6 @@ import com.naccoro.wask.utils.DateUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 
 public class ReplacementHistoryRepository {
@@ -53,6 +52,23 @@ public class ReplacementHistoryRepository {
             Log.d(TAG, "get: " + null);
             callback.onDataNotAvailable();
         }
+    }
+
+    public String getLastReplacement() {
+        checkCache();
+
+        if (cachedReplacementHistory.size() == 0) {
+            return null;
+        }
+
+        Collections.sort(cachedReplacementHistory, (firstHistory, secondHistory) -> {
+            int firstDate = DateUtils.getDateToInt(firstHistory.getReplacedDate());
+            int secondDate = DateUtils.getDateToInt(secondHistory.getReplacedDate());
+
+            return Integer.compare(firstDate, secondDate);
+        });
+
+        return cachedReplacementHistory.get(cachedReplacementHistory.size() - 1).getReplacedDate();
     }
     
     public void insert(ReplacementHistory newReplacementHistory, InsertHistoryCallback callback) {
@@ -152,23 +168,6 @@ public class ReplacementHistoryRepository {
         return null;
     }
 
-    public String getLastReplacement() {
-        checkCache();
-
-        if (cachedReplacementHistory.size() == 0) {
-            return null;
-        }
-
-        Collections.sort(cachedReplacementHistory, (firstHistory, secondHistory) -> {
-            int firstDate = DateUtils.getDateToInt(firstHistory.getReplacedDate());
-            int secondDate = DateUtils.getDateToInt(secondHistory.getReplacedDate());
-
-            return Integer.compare(firstDate, secondDate);
-        });
-
-        return cachedReplacementHistory.get(cachedReplacementHistory.size() - 1).getReplacedDate();
-    }
-
     public interface LoadHistoriesCallback {
 
         void onHistoriesLoaded(List<ReplacementHistory> histories);
@@ -184,6 +183,7 @@ public class ReplacementHistoryRepository {
     }
 
     public interface InsertHistoryCallback {
+
         void onSuccess();
 
         void onDuplicated();

--- a/app/src/main/java/com/naccoro/wask/replacement/repository/ReplacementHistoryRepository.java
+++ b/app/src/main/java/com/naccoro/wask/replacement/repository/ReplacementHistoryRepository.java
@@ -8,6 +8,8 @@ import com.naccoro.wask.replacement.model.ReplacementHistory;
 import com.naccoro.wask.utils.DateUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 public class ReplacementHistoryRepository {
@@ -148,6 +150,23 @@ public class ReplacementHistoryRepository {
             }
         }
         return null;
+    }
+
+    public String getLastReplacement() {
+        checkCache();
+
+        if (cachedReplacementHistory.size() == 0) {
+            return null;
+        }
+
+        Collections.sort(cachedReplacementHistory, (firstHistory, secondHistory) -> {
+            int firstDate = DateUtils.getDateToInt(firstHistory.getReplacedDate());
+            int secondDate = DateUtils.getDateToInt(secondHistory.getReplacedDate());
+
+            return Integer.compare(firstDate, secondDate);
+        });
+
+        return cachedReplacementHistory.get(cachedReplacementHistory.size() - 1).getReplacedDate();
     }
 
     public interface LoadHistoriesCallback {

--- a/app/src/main/java/com/naccoro/wask/utils/DateUtils.java
+++ b/app/src/main/java/com/naccoro/wask/utils/DateUtils.java
@@ -12,6 +12,72 @@ import java.util.regex.Pattern;
 public class DateUtils {
 
     /**
+     * 오늘 날짜와의 일수 차이를 구함
+     * @param date 비교 대상 날짜
+     * @return 정수형의 차이 일수
+     */
+    public static int calculateDateGapWithToday(int date) {
+        return calculateDateGap(date, getToday());
+    }
+
+    /**
+     * 두 일자 간의 일수 차이를 구함
+     * @param date 계산할 날짜
+     * @param targetDate 비교 대상이 되는 날짜
+     * @return 정수형의 차이 일수
+     */
+    public static int calculateDateGap(int date, int targetDate) {
+        GregorianCalendar dateCalendar =
+                new GregorianCalendar(getYear(date), getMonth(date), getDay(date), 0, 0);
+        GregorianCalendar targetDateCalendar =
+                new GregorianCalendar(getYear(targetDate), getMonth(targetDate), getDay(targetDate), 0, 0);
+
+        dateCalendar.set(Calendar.SECOND, 0);
+        dateCalendar.set(Calendar.MILLISECOND, 0);
+
+        targetDateCalendar.set(Calendar.SECOND, 0);
+        targetDateCalendar.set(Calendar.MILLISECOND, 0);
+
+        long diff = targetDateCalendar.getTimeInMillis() - dateCalendar.getTimeInMillis();
+
+        return (int) diff / (24 * 60 * 60 * 1000);
+    }
+
+    /**
+     * 입력받을 날짜를 입력받은 타입을 파싱하여 리턴
+     * @param type DateType.YEAR, DateType.MONTH, DateType.DAY 중 하나
+     * @param date 파싱할 날짜
+     * @return 파싱된 정수형
+     */
+    private static int getParsedDate(DateType type, int date) {
+        switch (type) {
+            case YEAR:
+                return parseDateToInt(date, 0, 4);
+
+            case MONTH:
+                return parseDateToInt(date, 4, 6);
+
+            case DAY:
+                return parseDateToInt(date, 6, 8);
+
+            default:
+                return -1;
+        }
+    }
+
+    /**
+     * 입력받은 날짜를 파싱
+     * @param date 파싱할 날짜
+     * @param start 피상할 시작 인덱스
+     * @param end 파싱할 마지막 인덱스
+     * @return 파싱된 날짜의 정수형
+     */
+    private static int parseDateToInt(int date, int start, int end) {
+        String dateString = checkDateFormat(date);
+        return Integer.parseInt(dateString.substring(start, end));
+    }
+
+    /**
      * 오늘 날짜를 YYYYMMDD 형식으로 가져오기
      * @return YYYYMMDD 형식의 오늘 날짜
      */
@@ -25,11 +91,15 @@ public class DateUtils {
      * @param calendar 날짜를 계산할 GregorianCalendar
      * @return YYYYMMDD 형태의 GregorianCalendar가 가진 날짜
      */
-    public static int getDateFromGregorianCalendar(GregorianCalendar calendar) {
+    private static int getDateFromGregorianCalendar(GregorianCalendar calendar) {
         String dateString = calendar.get(Calendar.YEAR) +
                 convertMonthIntToString(calendar.get(Calendar.MONTH) + 1) +
                 calendar.get(Calendar.DAY_OF_MONTH);
         return Integer.parseInt(dateString);
+    }
+
+    private static int getYear(int date) {
+        return getParsedDate(DateType.YEAR, date);
     }
 
     /**
@@ -38,8 +108,11 @@ public class DateUtils {
      * @return int 타입의 월
      */
     public static int getMonth(int date) {
-        String dateString = checkDateFormat(date);
-        return Integer.parseInt(dateString.substring(4, 6));
+        return getParsedDate(DateType.MONTH, date);
+    }
+
+    private static int getDay(int date) {
+        return getParsedDate(DateType.DAY, date);
     }
 
     /**
@@ -78,7 +151,7 @@ public class DateUtils {
      * @param month 변환할 int 형태의 월
      * @return MM 형태로 변환된 문자열
      */
-    public static String convertMonthIntToString(int month) {
+    private static String convertMonthIntToString(int month) {
         checkMonthFormat(month);
 
         StringBuilder newMonth = new StringBuilder();
@@ -97,7 +170,7 @@ public class DateUtils {
      * @param month 감사할 월
      * @return 유효한지 아닌지 boolean 형태로 리턴
      */
-    public static boolean isLegalMonth(int month) {
+    private static boolean isLegalMonth(int month) {
         return month > 0 && month <= 12;
     }
 
@@ -121,5 +194,9 @@ public class DateUtils {
      */
     private static boolean isLegalDate(String date) {
         return Pattern.matches("^\\d{4}(0[1-9]|1[012])(0[1-9]|[12][0-9]|3[01])$", date);
+    }
+
+    public enum DateType {
+        YEAR, MONTH, DAY
     }
 }

--- a/app/src/main/java/com/naccoro/wask/utils/DateUtils.java
+++ b/app/src/main/java/com/naccoro/wask/utils/DateUtils.java
@@ -93,11 +93,16 @@ public class DateUtils {
      */
     private static int getDateFromGregorianCalendar(GregorianCalendar calendar) {
         String dateString = calendar.get(Calendar.YEAR) +
-                convertMonthIntToString(calendar.get(Calendar.MONTH) + 1) +
-                calendar.get(Calendar.DAY_OF_MONTH);
+                convertMonthToString(calendar.get(Calendar.MONTH) + 1) +
+                convertDayToString(calendar.get(Calendar.DAY_OF_MONTH));
         return Integer.parseInt(dateString);
     }
 
+    /**
+     * YYYYMMDD 포맷에서 연도에 해당하는 정보를 리턴
+     * @param date 연도 정보를 조회할 YYYYMMDD 정수
+     * @return int 타입의 연도
+     */
     private static int getYear(int date) {
         return getParsedDate(DateType.YEAR, date);
     }
@@ -111,18 +116,13 @@ public class DateUtils {
         return getParsedDate(DateType.MONTH, date);
     }
 
+    /**
+     * YYYYMMDD 포맷에서 "일"에 해당하는 정보를 리턴
+     * @param date "일" 정보를 조회할 YYYYMMDD 정수
+     * @return int 타입의 일
+     */
     private static int getDay(int date) {
         return getParsedDate(DateType.DAY, date);
-    }
-
-    /**
-     * 입력받은 '월" 정보의 유효성 검사
-     * @param month 검사할 월
-     */
-    public static void checkMonthFormat(int month) {
-        if (!isLegalMonth(month)) {
-            throw new IllegalArgumentException("month parameter should be 0 to 12");
-        }
     }
 
     /**
@@ -140,38 +140,47 @@ public class DateUtils {
 
         StringBuilder newReplaceDate = new StringBuilder()
                 .append(dateSplitArray[0])
-                .append(DateUtils.convertMonthIntToString(month))
+                .append(DateUtils.convertMonthToString(month))
                 .append(dateSplitArray[2]);
 
         return Integer.parseInt(newReplaceDate.toString());
     }
 
     /**
-     * int 타입의 월을 MM 형태의 문자열로 변환
-     * @param month 변환할 int 형태의 월
-     * @return MM 형태로 변환된 문자열
+     * 정수형의 월 값을 문자열로 변경
+     * @param month 변경할 월 값
+     * @return 월 문자열
      */
-    private static String convertMonthIntToString(int month) {
+    private static String convertMonthToString(int month) {
         checkMonthFormat(month);
-
-        StringBuilder newMonth = new StringBuilder();
-
-        if (month < 10) {
-            newMonth.append(0);
-        }
-
-        newMonth.append(month);
-
-        return newMonth.toString();
+        return convertDoubleDigitForm(month);
     }
 
     /**
-     * 입력받은 '월" 정보의 유효성 검사하여 리턴
-     * @param month 감사할 월
-     * @return 유효한지 아닌지 boolean 형태로 리턴
+     * 정수형의 월 값을 문자열로 변경
+     * @param day 변경할 월 값
+     * @return 월 문자열
      */
-    private static boolean isLegalMonth(int month) {
-        return month > 0 && month <= 12;
+    private static String convertDayToString(int day) {
+        checkDayFormat(day);
+        return convertDoubleDigitForm(day);
+    }
+
+    /**
+     * int 타입의 값을 두 자릿수 형태의 문자열로 변환
+     * @param value 변환할 int 형태의 값
+     * @return 두 자릿수 형태로 변환된 문자열
+     */
+    private static String convertDoubleDigitForm(int value) {
+        StringBuilder newValue = new StringBuilder();
+
+        if (value < 10) {
+            newValue.append(0);
+        }
+
+        newValue.append(value);
+
+        return newValue.toString();
     }
 
     /**
@@ -188,12 +197,50 @@ public class DateUtils {
     }
 
     /**
+     * 입력받은 '월" 정보의 유효성 검사
+     * @param month 검사할 월
+     */
+    public static void checkMonthFormat(int month) {
+        if (!isLegalMonth(month)) {
+            throw new IllegalArgumentException("month parameter should be 1 to 12");
+        }
+    }
+
+    /**
+     * 입력받은 '일" 정보의 유효성 검사
+     * @param day 검사할 일
+     */
+    private static void checkDayFormat(int day) {
+        if (!isLegalDay(day)) {
+            throw new IllegalArgumentException("month parameter should be 1 to 31");
+        }
+    }
+
+    /**
      * 입력받은 YYYYMMDD 문자열의 형태가 유효한지 검사하여 리턴
      * @param date 검사할 문자열
      * @return 유효한지 아닌지 boolean 형태로 리턴
      */
     private static boolean isLegalDate(String date) {
         return Pattern.matches("^\\d{4}(0[1-9]|1[012])(0[1-9]|[12][0-9]|3[01])$", date);
+    }
+
+    /**
+     * 입력받은 '월" 정보의 유효성 검사하여 리턴
+     * @param month 검사할 월
+     * @return 유효한지 아닌지 boolean 형태로 리턴
+     */
+    private static boolean isLegalMonth(int month) {
+        return month > 0 && month <= 12;
+    }
+
+    /**
+     * 입력받은 '일" 정보의 유효성 검사하여 리턴
+     * @param day 검사할 일
+     * @return 유효한지 아닌지 boolean 형태로 리턴
+     */
+    private static boolean isLegalDay(int day) {
+        return day > 0 && day <= 31;
     }
 
     public enum DateType {

--- a/app/src/main/java/com/naccoro/wask/utils/DateUtils.java
+++ b/app/src/main/java/com/naccoro/wask/utils/DateUtils.java
@@ -16,6 +16,10 @@ public class DateUtils {
         return getDateFromGregorianCalendar(calendar);
     }
 
+    public static int getTodayToInt() {
+        return getDateToInt(getToday());
+    }
+
     public static String getDateFromGregorianCalendar(GregorianCalendar calendar) {
         return calendar.get(Calendar.YEAR) + "-" +
                 convertMonthIntToString(calendar.get(Calendar.MONTH) + 1) + "-" +
@@ -108,5 +112,9 @@ public class DateUtils {
      */
     private static boolean isLegalDate(String date) {
         return Pattern.matches("^\\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$", date);
+    }
+
+    public static int getDateToInt(String date) {
+        return Integer.parseInt(date.replaceAll("-", ""));
     }
 }

--- a/app/src/main/java/com/naccoro/wask/utils/DateUtils.java
+++ b/app/src/main/java/com/naccoro/wask/utils/DateUtils.java
@@ -12,56 +12,39 @@ import java.util.regex.Pattern;
 public class DateUtils {
 
     /**
-     * 오늘 날짜를 YYYY-MM-DD 형식으로 가져오기
-     * @return YYYY-MM-DD 형식의 오늘 날짜
+     * 오늘 날짜를 YYYYMMDD 형식으로 가져오기
+     * @return YYYYMMDD 형식의 오늘 날짜
      */
-    public static String getToday() {
+    public static int getToday() {
         GregorianCalendar calendar = new GregorianCalendar();
         return getDateFromGregorianCalendar(calendar);
     }
 
     /**
-     * 오늘 날짜를 YYYYMMDD 정수형으로 가져오기
-     * @return YYYYMMDD 정수형의 오늘 날짜
-     */
-    public static int getTodayToInt() {
-        return getDateToInt(getToday());
-    }
-
-    /**
-     * 입력받은 YYYY-MM-DD 형태의 날짜를 정수형으로 전환
-     * @param date 정수형으로 바꿀 YYYY-MM-DD 문자열
-     * @return 정수형의 YYYY-MM-DD 문자열
-     */
-    public static int getDateToInt(String date) {
-        checkDateFormat(date);
-        return Integer.parseInt(date.replaceAll("-", ""));
-    }
-
-    /**
-     * GregorianCalendar를 이용하여 YYYY-MM-DD 형태의 날짜 구하기
+     * GregorianCalendar를 이용하여 YYYYMMDD 형태의 날짜 구하기
      * @param calendar 날짜를 계산할 GregorianCalendar
-     * @return YYYY-MM-DD 형태의 GregorianCalendar가 가진 날짜
+     * @return YYYYMMDD 형태의 GregorianCalendar가 가진 날짜
      */
-    public static String getDateFromGregorianCalendar(GregorianCalendar calendar) {
-        return calendar.get(Calendar.YEAR) + "-" +
-                convertMonthIntToString(calendar.get(Calendar.MONTH) + 1) + "-" +
+    public static int getDateFromGregorianCalendar(GregorianCalendar calendar) {
+        String dateString = calendar.get(Calendar.YEAR) +
+                convertMonthIntToString(calendar.get(Calendar.MONTH) + 1) +
                 calendar.get(Calendar.DAY_OF_MONTH);
+        return Integer.parseInt(dateString);
     }
 
     /**
-     * YYYY-MM-DD 포멧에서 "월"에 해당하는 정보를 리턴
-     * @param date "월" 정보를 조회할 YYYY-MM-DD 문자열
+     * YYYYMMDD 포맷에서 "월"에 해당하는 정보를 리턴
+     * @param date "월" 정보를 조회할 YYYYMMDD 정수
      * @return int 타입의 월
      */
-    public static int getMonth(String date) {
-        checkDateFormat(date);
-        return Integer.parseInt(date.substring(5, 7));
+    public static int getMonth(int date) {
+        String dateString = checkDateFormat(date);
+        return Integer.parseInt(dateString.substring(5, 7));
     }
 
     /**
      * 입력받은 '월" 정보의 유효성 검사
-     * @param month 감사할 월
+     * @param month 검사할 월
      */
     public static void checkMonthFormat(int month) {
         if (!isLegalMonth(month)) {
@@ -70,24 +53,24 @@ public class DateUtils {
     }
 
     /**
-     * YYYY-MM-DD 포멧에서 월 정보를 수정
-     * @param date 수정할 대상 YYYY-MM-DD 문자열
+     * YYYYMMDD 포맷에서 월 정보를 수정
+     * @param date 수정할 대상 YYYYMMDD 정수
      * @param month 수정할 월
-     * @return 수정된 YYYY-MM-DD 문자열
+     * @return 수정된 YYYYMMDD 정수
      */
-    public static String replaceMonthOfDateFormat(String date, int month) {
+    public static int replaceMonthOfDateFormat(int date, int month) {
         DateUtils.checkMonthFormat(month);
 
-        String[] dateSplitArray = date.split("-");
+        String dataString = String.valueOf(date);
+
+        String[] dateSplitArray = {dataString.substring(0, 3), dataString.substring(3, 5), dataString.substring(5, 7)};
 
         StringBuilder newReplaceDate = new StringBuilder()
                 .append(dateSplitArray[0])
-                .append("-")
                 .append(DateUtils.convertMonthIntToString(month))
-                .append("-")
                 .append(dateSplitArray[2]);
 
-        return newReplaceDate.toString();
+        return Integer.parseInt(newReplaceDate.toString());
     }
 
     /**
@@ -119,21 +102,24 @@ public class DateUtils {
     }
 
     /**
-     * 입력받은 YYYY-MM-DD 문자열의 형태가 유효한지 검사
-     * @param date 검사할 문자열
+     * 입력받은 YYYYMMDD 정수 형태가 유효한지 검사
+     * @param date 검사할 정수
+     * @return 검사한 문자열
      */
-    private static void checkDateFormat(String date) {
-        if (!isLegalDate(date)) {
-            throw new IllegalArgumentException("date parameter should be YYYY-MM-DD format");
+    private static String checkDateFormat(int date) {
+        String dateString = String.valueOf(date);
+        if (!isLegalDate(dateString)) {
+            throw new IllegalArgumentException("date parameter should be YYYYMMDD format");
         }
+        return dateString;
     }
 
     /**
-     * 입력받은 YYYY-MM-DD 문자열의 형태가 유효한지 검사하여 리턴
+     * 입력받은 YYYYMMDD 문자열의 형태가 유효한지 검사하여 리턴
      * @param date 검사할 문자열
      * @return 유효한지 아닌지 boolean 형태로 리턴
      */
     private static boolean isLegalDate(String date) {
-        return Pattern.matches("^\\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$", date);
+        return Pattern.matches("^\\d{4}(0[1-9]|1[012])(0[1-9]|[12][0-9]|3[01])$", date);
     }
 }

--- a/app/src/main/java/com/naccoro/wask/utils/DateUtils.java
+++ b/app/src/main/java/com/naccoro/wask/utils/DateUtils.java
@@ -11,15 +11,38 @@ import java.util.regex.Pattern;
  */
 public class DateUtils {
 
+    /**
+     * 오늘 날짜를 YYYY-MM-DD 형식으로 가져오기
+     * @return YYYY-MM-DD 형식의 오늘 날짜
+     */
     public static String getToday() {
         GregorianCalendar calendar = new GregorianCalendar();
         return getDateFromGregorianCalendar(calendar);
     }
 
+    /**
+     * 오늘 날짜를 YYYYMMDD 정수형으로 가져오기
+     * @return YYYYMMDD 정수형의 오늘 날짜
+     */
     public static int getTodayToInt() {
         return getDateToInt(getToday());
     }
 
+    /**
+     * 입력받은 YYYY-MM-DD 형태의 날짜를 정수형으로 전환
+     * @param date 정수형으로 바꿀 YYYY-MM-DD 문자열
+     * @return 정수형의 YYYY-MM-DD 문자열
+     */
+    public static int getDateToInt(String date) {
+        checkDateFormat(date);
+        return Integer.parseInt(date.replaceAll("-", ""));
+    }
+
+    /**
+     * GregorianCalendar를 이용하여 YYYY-MM-DD 형태의 날짜 구하기
+     * @param calendar 날짜를 계산할 GregorianCalendar
+     * @return YYYY-MM-DD 형태의 GregorianCalendar가 가진 날짜
+     */
     public static String getDateFromGregorianCalendar(GregorianCalendar calendar) {
         return calendar.get(Calendar.YEAR) + "-" +
                 convertMonthIntToString(calendar.get(Calendar.MONTH) + 1) + "-" +
@@ -112,9 +135,5 @@ public class DateUtils {
      */
     private static boolean isLegalDate(String date) {
         return Pattern.matches("^\\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$", date);
-    }
-
-    public static int getDateToInt(String date) {
-        return Integer.parseInt(date.replaceAll("-", ""));
     }
 }

--- a/app/src/main/java/com/naccoro/wask/utils/DateUtils.java
+++ b/app/src/main/java/com/naccoro/wask/utils/DateUtils.java
@@ -39,7 +39,7 @@ public class DateUtils {
      */
     public static int getMonth(int date) {
         String dateString = checkDateFormat(date);
-        return Integer.parseInt(dateString.substring(5, 7));
+        return Integer.parseInt(dateString.substring(4, 6));
     }
 
     /**
@@ -63,7 +63,7 @@ public class DateUtils {
 
         String dataString = String.valueOf(date);
 
-        String[] dateSplitArray = {dataString.substring(0, 3), dataString.substring(3, 5), dataString.substring(5, 7)};
+        String[] dateSplitArray = {dataString.substring(0, 4), dataString.substring(4, 6), dataString.substring(6)};
 
         StringBuilder newReplaceDate = new StringBuilder()
                 .append(dateSplitArray[0])

--- a/app/src/main/java/com/naccoro/wask/utils/DateUtils.java
+++ b/app/src/main/java/com/naccoro/wask/utils/DateUtils.java
@@ -1,5 +1,7 @@
 package com.naccoro.wask.utils;
 
+import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.regex.Pattern;
 
 /**
@@ -8,6 +10,18 @@ import java.util.regex.Pattern;
  * @since 2020.08.08
  */
 public class DateUtils {
+
+    public static String getToday() {
+        GregorianCalendar calendar = new GregorianCalendar();
+        return getDateFromGregorianCalendar(calendar);
+    }
+
+    public static String getDateFromGregorianCalendar(GregorianCalendar calendar) {
+        return calendar.get(Calendar.YEAR) + "-" +
+                convertMonthIntToString(calendar.get(Calendar.MONTH) + 1) + "-" +
+                calendar.get(Calendar.DAY_OF_MONTH);
+    }
+
     /**
      * YYYY-MM-DD 포멧에서 "월"에 해당하는 정보를 리턴
      * @param date "월" 정보를 조회할 YYYY-MM-DD 문자열

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -138,8 +138,7 @@
                 android:layout_height="wrap_content"
                 android:text="@string/main_use_period_message"
                 android:textColor="@color/waskGrayFont"
-                android:textSize="@dimen/textsize_mainuseperiod_text"
-                android:textStyle="bold" />
+                android:textSize="@dimen/textsize_mainuseperiod_text"/>
         </LinearLayout>
 
         <TextView

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -146,6 +146,7 @@
             android:id="@+id/button_change"
             android:layout_width="0dp"
             android:layout_height="0dp"
+            android:foreground="?android:selectableItemBackground"
             android:background="@drawable/bg_button_change"
             android:elevation="8dp"
             android:text="@string/main_change_button"

--- a/app/src/main/res/layout/dialog_wask.xml
+++ b/app/src/main/res/layout/dialog_wask.xml
@@ -47,6 +47,7 @@
                 android:layout_height="wrap_content"
                 android:text="다이얼로그의 메시지가 들어갈 공간"
                 style="@style/WaskDialogText"
+                android:textFontWeight="400"
                 android:layout_gravity="center"
                 android:layout_marginTop="56dp"
                 android:layout_marginBottom="56dp"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,8 +15,10 @@
     <string name="main_card_good">마스크 1일 1사용을 권장합니다</string>
     <string name="main_card_bad">마스크를 교체하는 것을 권장합니다</string>
     <string name="main_use_period_message">일 째 사용중</string>
+    <string name="main_use_period_message_no_replacement">교체 기록이 없습니다.</string>
     <string name="main_change_button">교체하기</string>
 
     <string name="dialog_replacementcycle">일</string>
     <string name="dialog_replacelater">일 뒤 교체</string>
+    <string name="dialog_cancelreplacement">교체 기록을\n취소하시겠습니까?</string>
 </resources>

--- a/app/src/test/java/com/naccoro/wask/DateUtilsTest.java
+++ b/app/src/test/java/com/naccoro/wask/DateUtilsTest.java
@@ -29,4 +29,19 @@ public class DateUtilsTest {
     public void getTodayString_isCorrect() {
         assertThat(DateUtils.getToday(), is(20200813));
     }
+
+    @Test
+    public void calculateDateGap_isCorrect() {
+        assertThat(DateUtils.calculateDateGap(20200813, 20200817), is(4));
+        assertThat(DateUtils.calculateDateGap(20200729, 20200801), is(3));
+        assertThat(DateUtils.calculateDateGap(20191230, 20200101), is(2));
+    }
+
+    @Test
+    public void calculateDateGapWithToday_isCorrect() {
+        assertThat(DateUtils.calculateDateGapWithToday(20200813), is(0));
+        assertThat(DateUtils.calculateDateGapWithToday(20200809), is(4));
+        assertThat(DateUtils.calculateDateGapWithToday(20200730), is(14));
+        assertThat(DateUtils.calculateDateGapWithToday(20200815), is(-2));
+    }
 }

--- a/app/src/test/java/com/naccoro/wask/DateUtilsTest.java
+++ b/app/src/test/java/com/naccoro/wask/DateUtilsTest.java
@@ -10,30 +10,23 @@ import static org.junit.Assert.assertThat;
 public class DateUtilsTest {
     @Test
     public void regularExpression_isCorrect() {
-        assertThat(DateUtils.getMonth("2020-03-11"), is(3));
-        assertThat(DateUtils.getMonth("2021-06-21"), is(6));
-        assertThat(DateUtils.getMonth("2019-12-31"), is(12));
-        assertThat(DateUtils.getMonth("2020-01-01"), is(1));
+        assertThat(DateUtils.getMonth(20200311), is(3));
+        assertThat(DateUtils.getMonth(20210621), is(6));
+        assertThat(DateUtils.getMonth(20191231), is(12));
+        assertThat(DateUtils.getMonth(20200101), is(1));
     }
 
     @Test
     public void updateMonth_isCorrect() {
-        assertThat(DateUtils.replaceMonthOfDateFormat("2020-01-12", 4), is("2020-04-12"));
-        assertThat(DateUtils.replaceMonthOfDateFormat("2020-04-14", 1), is("2020-01-14"));
-        assertThat(DateUtils.replaceMonthOfDateFormat("2020-12-01", 5), is("2020-05-01"));
-        assertThat(DateUtils.replaceMonthOfDateFormat("2020-02-22", 12), is("2020-12-22"));
-        assertThat(DateUtils.replaceMonthOfDateFormat("2020-11-02", 12), is("2020-12-02"));
+        assertThat(DateUtils.replaceMonthOfDateFormat(20200112, 4), is(20200412));
+        assertThat(DateUtils.replaceMonthOfDateFormat(20200414, 1), is(20200114));
+        assertThat(DateUtils.replaceMonthOfDateFormat(20201201, 5), is(20200501));
+        assertThat(DateUtils.replaceMonthOfDateFormat(20200222, 12), is(20201222));
+        assertThat(DateUtils.replaceMonthOfDateFormat(20201102, 12), is(20201202));
     }
 
     @Test
     public void getTodayString_isCorrect() {
-        assertThat(DateUtils.getToday(), is("2020-08-11"));
-    }
-
-    @Test
-    public void getDateToInt_isCorrect() {
-        assertThat(DateUtils.getDateToInt("2020-08-12"), is(20200812));
-        assertThat(DateUtils.getDateToInt("2022-10-10"), is(20221010));
-        assertThat(DateUtils.getDateToInt("2010-12-31"), is(20101231));
+        assertThat(DateUtils.getToday(), is(20200813));
     }
 }

--- a/app/src/test/java/com/naccoro/wask/DateUtilsTest.java
+++ b/app/src/test/java/com/naccoro/wask/DateUtilsTest.java
@@ -29,4 +29,11 @@ public class DateUtilsTest {
     public void getTodayString_isCorrect() {
         assertThat(DateUtils.getToday(), is("2020-08-11"));
     }
+
+    @Test
+    public void getDateToInt_isCorrect() {
+        assertThat(DateUtils.getDateToInt("2020-08-12"), is(20200812));
+        assertThat(DateUtils.getDateToInt("2022-10-10"), is(20221010));
+        assertThat(DateUtils.getDateToInt("2010-12-31"), is(20101231));
+    }
 }

--- a/app/src/test/java/com/naccoro/wask/DateUtilsTest.java
+++ b/app/src/test/java/com/naccoro/wask/DateUtilsTest.java
@@ -24,4 +24,9 @@ public class DateUtilsTest {
         assertThat(DateUtils.replaceMonthOfDateFormat("2020-02-22", 12), is("2020-12-22"));
         assertThat(DateUtils.replaceMonthOfDateFormat("2020-11-02", 12), is("2020-12-02"));
     }
+
+    @Test
+    public void getTodayString_isCorrect() {
+        assertThat(DateUtils.getToday(), is("2020-08-11"));
+    }
 }


### PR DESCRIPTION
교체하기 기능을 추가하였습니다.

### 고민할 점
- `Room`에서 `Date` 형태를 저장할 수 없기 때문에 YYYY-MM-DD 형태의 문자열을 대신 사용하고 있어서 이를 가공하는 `DateUtil` 클래스 또한 사용하고 있습니다.
오늘 날짜 구하기, 오늘 날짜와 다른 날짜의 일수 차이 구하기 등의 로직은 과연 `DataUtil` 에 모두 포함되는 것이 맞을까요? 
관련된 가공 기능이 많아질 수록 `Repository`, `Util`, `Presenter` 셋 중 어디에 위치하는 것이 올바른지 애매해지고 있습니다.
현재 구현한 위치가 괜찮을까요?

- 달력을 구현하고 교체 일자를 나타내는 로직을 작성할 때, YYYY-MM-DD 의 형태를 계속 사용하면 불편할 것이라고 생각했습니다. 따라서 `ReplacementHistory` 객체는 `ID`값을 가지고 이를 `Primary key`로 사용하고 있는데, 사실 YYYY-MM-DD 또한 중복되어서는 안되고 `Primary key` 로 충분한 역할을 할 수 있습니다. 그러나 `Room`에서는 합성키를 지원하지 않아 `Primary key`를 묶어 사용하려면 `autoGerneated` 속성을 사용할 수 없습니다. (이는 `ID` 칼럼을 사용하는데 큰 제약입니다.)
    - 지금 처럼 ID 칼럼을 `Primary key`로 갖고, YYYY-MM-DD는 그냥 `Unique` 제약만 걸어두는 것이 좋을까요?
    - 아니면 ID 칼럼을 없애고 YYYY-MM-DD 값만 프라이머리 키로 갖는 것이 좋을까요?
        - 이 경우, 해당 날짜가 DB에 존재하는지 확인하는 등의 로직이 조금 더 수월해집니다. (현재는 ID 값을 빼고 비교하도록 `equare` 메서드 재작성)

### 수정해야할 것
- 교체 기록이 없을 때 (앱을 처음 사용할 때) 어떻게 할 지 정해야합니다! 우선은 0일째 사용중으로 보이도록 하였습니다 !

로직이 복잡해지면서 코드가 약간 마음에 안들지만 어디를 콕 찝기가 어렵습니다. 피드백 난도질 부탁드립니다 !


![KakaoTalk_Image_2020-08-12-01-00-19](https://user-images.githubusercontent.com/57310034/89920336-3e044280-dc37-11ea-85ad-be74fbb7b912.gif)
