### PR TITLE
fix: 달력에서 교체 수정 시 메인화면 교체하기 버튼이 이상해지는 버그 수정

### DIFF
--- a/app/src/main/java/com/naccoro/wask/WaskApplication.java
+++ b/app/src/main/java/com/naccoro/wask/WaskApplication.java
@@ -14,7 +14,9 @@ import static com.naccoro.wask.preferences.SettingPreferenceManager.SettingPushA
 
 public class WaskApplication extends Application {
 
-    public static final String CHANNEL_ID="WaskChannel";
+    public static final String CHANNEL_ID = "WaskChannel";
+
+    public static boolean isChanged;
 
     @Override
     public void onCreate() {

--- a/app/src/main/java/com/naccoro/wask/calendar/CalendarAdapter.java
+++ b/app/src/main/java/com/naccoro/wask/calendar/CalendarAdapter.java
@@ -8,6 +8,7 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import com.naccoro.wask.WaskApplication;
 import com.naccoro.wask.preferences.SettingPreferenceManager;
 import com.naccoro.wask.replacement.repository.ReplacementHistoryRepository;
 import com.naccoro.wask.utils.AlarmUtil;
@@ -201,6 +202,9 @@ public class CalendarAdapter extends RecyclerView.Adapter<CalendarAdapter.Calend
         if (SettingPreferenceManager.getIsShowNotificationBar()) {
             int period = getMaskPeriod();
             Log.d("MaksPeriod", period + "");
+
+            WaskApplication.isChanged = period == 1;
+
             if (period > 0) {
                 AlarmUtil.showForegroundService(context, period);
 

--- a/app/src/main/java/com/naccoro/wask/main/MainPresenter.java
+++ b/app/src/main/java/com/naccoro/wask/main/MainPresenter.java
@@ -3,6 +3,7 @@ package com.naccoro.wask.main;
 
 import android.content.Context;
 
+import com.naccoro.wask.WaskApplication;
 import com.naccoro.wask.preferences.SettingPreferenceManager;
 import com.naccoro.wask.utils.AlarmUtil;
 import com.naccoro.wask.utils.DateUtils;
@@ -18,8 +19,6 @@ public class MainPresenter implements MainContract.Presenter {
     private ReplacementHistoryRepository replacementHistoryRepository;
 
     private boolean isNoData = true;
-
-    private boolean isChanged = false;
 
     MainContract.View mainView;
 
@@ -48,7 +47,7 @@ public class MainPresenter implements MainContract.Presenter {
             mainView.enableReplaceButton();
         } else {
             //교체한 당일
-            isChanged = true;
+            WaskApplication.isChanged = true;
             mainView.showGoodMainView();
             mainView.disableReplaceButton();
         }
@@ -80,7 +79,7 @@ public class MainPresenter implements MainContract.Presenter {
     @Override
     public void changeMask(Context context) {
 
-        if (!isChanged) {
+        if (!WaskApplication.isChanged) {
             checkIsFirstReplacement();
 
             replacementHistoryRepository.insertToday(new ReplacementHistoryRepository.InsertHistoryCallback() {
@@ -88,7 +87,7 @@ public class MainPresenter implements MainContract.Presenter {
                 public void onSuccess() {
                     mainView.showReplaceToast();
                     mainView.enableReplaceButton();
-                    isChanged = true;
+                    WaskApplication.isChanged = true;
 
                     start();
 
@@ -111,7 +110,7 @@ public class MainPresenter implements MainContract.Presenter {
     @Override
     public void cancelChanging(Context context) {
         replacementHistoryRepository.deleteToday();
-        isChanged = false;
+        WaskApplication.isChanged = false;
 
         //메인화면 갱신
         start();


### PR DESCRIPTION
Resolves: #53 
달력에서 교체 일자를 변경하여도 `MainPresenter`가 크게 의존하고 있는` isChanged`에 영향을 주지 못해서 `WaskApplication`이 `isChanged` 변수를 가지고 있도록 하여 해결하였습니다.