### PR TITLE
Feature/calendar circle only today

### DIFF
--- a/app/src/main/java/com/naccoro/wask/calendar/CalendarActivity.java
+++ b/app/src/main/java/com/naccoro/wask/calendar/CalendarActivity.java
@@ -2,7 +2,6 @@ package com.naccoro.wask.calendar;
 
 import android.os.Bundle;
 import android.view.View;
-import android.widget.ImageView;
 import android.widget.Switch;
 import android.widget.TextView;
 
@@ -34,7 +33,7 @@ public class CalendarActivity extends AppCompatActivity
 
     WaskToolbar toolbar;
 
-    Date selectDate; // DatePicker로 선택된 날짜 <Calendar에서 핵심역할>
+    Date selectDate; // DatePicker로 선택된 날짜
 
     // 화면에 표시되는 달력 데이터 저장 (저번달 짜투리 + 이번달(1~30) + 다음달 조금)
     ArrayList<CalendarItem> dateList = new ArrayList<CalendarItem>();
@@ -189,6 +188,19 @@ public class CalendarActivity extends AppCompatActivity
 
         public void setDay(int day) {
             this.day = day;
+        }
+
+        public boolean isSameDate(GregorianCalendar cal) {
+            if (cal.get(Calendar.YEAR) != year) {
+                return false;
+            }
+            if (cal.get(Calendar.MONTH) != month) {
+                return false;
+            }
+            if (cal.get(Calendar.DATE) != day) {
+                return false;
+            }
+            return true;
         }
     }
 }

--- a/app/src/main/java/com/naccoro/wask/calendar/CalendarAdapter.java
+++ b/app/src/main/java/com/naccoro/wask/calendar/CalendarAdapter.java
@@ -157,7 +157,7 @@ public class CalendarAdapter extends RecyclerView.Adapter<CalendarAdapter.Calend
         item.setSelect(true);
         selectPosition = position; // select로 지정
 
-        // 미래는 마스크 교체유무 변경 제한
+        // 미래는 마스크 교체여부 변경 제한
         if (clickItem.get(Calendar.YEAR) > today.getYear()) {
             return;
         } else if (clickItem.get(Calendar.MONTH) > today.getMonth()) {
@@ -166,7 +166,7 @@ public class CalendarAdapter extends RecyclerView.Adapter<CalendarAdapter.Calend
             return;
         }
 
-        // 마스크 교체유무 변경
+        // 마스크 교체여부 변경
         if (item.isChangeMask()) {
             item.setChangeMask(false);
             replacementHistoryRepository.delete(DateUtils.getDateFromGregorianCalendar(item.getDate()));

--- a/app/src/main/java/com/naccoro/wask/calendar/CalendarAdapter.java
+++ b/app/src/main/java/com/naccoro/wask/calendar/CalendarAdapter.java
@@ -107,18 +107,15 @@ public class CalendarAdapter extends RecyclerView.Adapter<CalendarAdapter.Calend
 
         View itemView = calendarViewHolder.getItemView();
 
-        // 일요일은 빨간날
-        if (position % 7 == 0) {
-            calendarViewHolder.dateTextView.setTextColor(itemView.getContext().getColor(color.waskRed));
-        } else {
-            calendarViewHolder.dateTextView.setTextColor(itemView.getContext().getColor(color.black));
-        }
-
-        // 오늘이면 동그라미 표시
+        // 날짜(Day) 부분
         if (item.isSelect()) {
-            selectPosition = position; // 어댑터속에 저장! (나중에 지우기 위해)
+            // 오늘이면 동그라미 표시
             calendarViewHolder.dateTextView.setTextColor(itemView.getContext().getColor(color.white));
             calendarViewHolder.dateBackgroundImageView.setVisibility(View.VISIBLE);
+        } else if (position % 7 == 0) {
+            // 일요일은 빨간날
+            calendarViewHolder.dateTextView.setTextColor(itemView.getContext().getColor(color.waskRed));
+            calendarViewHolder.dateBackgroundImageView.setVisibility(View.GONE);
         } else {
             calendarViewHolder.dateTextView.setTextColor(itemView.getContext().getColor(color.black));
             calendarViewHolder.dateBackgroundImageView.setVisibility(View.GONE);

--- a/app/src/main/java/com/naccoro/wask/calendar/CalendarAdapter.java
+++ b/app/src/main/java/com/naccoro/wask/calendar/CalendarAdapter.java
@@ -30,7 +30,6 @@ public class CalendarAdapter extends RecyclerView.Adapter<CalendarAdapter.Calend
     private Context context;
     private ArrayList<CalendarItem> calendarList;
     private boolean isModifyMode;
-    private int selectPosition;
 
     private static Date today;
     private ReplacementHistoryRepository replacementHistoryRepository;
@@ -108,7 +107,7 @@ public class CalendarAdapter extends RecyclerView.Adapter<CalendarAdapter.Calend
         View itemView = calendarViewHolder.getItemView();
 
         // 날짜(Day) 부분
-        if (item.isSelect()) {
+        if (today.isSameDate(item.getDate())) {
             // 오늘이면 동그라미 표시
             calendarViewHolder.dateTextView.setTextColor(itemView.getContext().getColor(color.white));
             calendarViewHolder.dateBackgroundImageView.setVisibility(View.VISIBLE);
@@ -146,13 +145,6 @@ public class CalendarAdapter extends RecyclerView.Adapter<CalendarAdapter.Calend
     private void onDayClick(CalendarViewHolder calendarViewHolder, CalendarItem item, int position) {
 
         GregorianCalendar clickItem = item.getDate();
-
-        calendarList.get(selectPosition).setSelect(false); // 이전 선택 해제
-        notifyItemChanged(selectPosition);
-
-
-        item.setSelect(true);
-        selectPosition = position; // select로 지정
 
         // 미래는 마스크 교체여부 변경 제한
         if (clickItem.get(Calendar.YEAR) > today.getYear()) {

--- a/app/src/main/java/com/naccoro/wask/calendar/CalendarItem.java
+++ b/app/src/main/java/com/naccoro/wask/calendar/CalendarItem.java
@@ -6,25 +6,15 @@ import java.util.GregorianCalendar;
  * 캘린더에 표시되는 '일(Day)'이 하나씩 들어가는 객체
  */
 public class CalendarItem {
-    private boolean isSelect; // 오늘인지
     private boolean isChangeMask; // 마스크 교체했는지
     private boolean isCurrentMonth; // 이번달인지
 
     private GregorianCalendar date; // 날짜 데이터
 
-    public CalendarItem(boolean isSelect, boolean isChangeMask, boolean isCurrentMonth, GregorianCalendar date) {
-        this.isSelect = isSelect;
+    public CalendarItem(boolean isChangeMask, boolean isCurrentMonth, GregorianCalendar date) {
         this.isChangeMask = isChangeMask;
         this.isCurrentMonth = isCurrentMonth;
         this.date = date;
-    }
-
-    public boolean isSelect() {
-        return isSelect;
-    }
-
-    public void setSelect(boolean select) {
-        isSelect = select;
     }
 
     public boolean isChangeMask() {

--- a/app/src/main/java/com/naccoro/wask/calendar/CalendarModel.java
+++ b/app/src/main/java/com/naccoro/wask/calendar/CalendarModel.java
@@ -105,7 +105,7 @@ public class CalendarModel {
             GregorianCalendar item = new GregorianCalendar(prevCalendar.get(Calendar.YEAR), prevCalendar.get(Calendar.MONTH), lastDayOfPreMonth - j);
             isChangedMask = replacementHistories.contains(DateUtils.getDateFromGregorianCalendar(item));
 
-            dateList.add(0, new CalendarItem(false, isChangedMask,false, item));
+            dateList.add(0, new CalendarItem(isChangedMask,false, item));
         }
 
     }
@@ -124,12 +124,7 @@ public class CalendarModel {
             GregorianCalendar item = new GregorianCalendar(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH), j);
             isChangedMask = replacementHistories.contains(DateUtils.getDateFromGregorianCalendar(item));
 
-            if (selectDate.getDay() == j) {
-                // 선택일자와 같으면 select 체크
-                dateList.add(new CalendarItem(true, isChangedMask, true, item));
-            } else {
-                dateList.add(new CalendarItem(false, isChangedMask, true, item));
-            }
+            dateList.add(new CalendarItem(isChangedMask, true, item));
         }
     }
 
@@ -150,7 +145,7 @@ public class CalendarModel {
             GregorianCalendar item = new GregorianCalendar(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH) + 1, j);
             isChangedMask = replacementHistories.contains(DateUtils.getDateFromGregorianCalendar(item));
 
-            dateList.add(new CalendarItem(false, isChangedMask, false, item));
+            dateList.add(new CalendarItem(isChangedMask, false, item));
         }
     }
 

--- a/app/src/main/res/layout/activity_calendar.xml
+++ b/app/src/main/res/layout/activity_calendar.xml
@@ -70,7 +70,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:foreground="?android:selectableItemBackground"
-            android:layout_marginTop="@dimen/padding_calendar_changebutton"
+            android:paddingVertical="@dimen/padding_calendar_changebutton"
+            android:paddingEnd="@dimen/padding_calendar_changebutton"
             android:layout_marginLeft="@dimen/margin_calendar_textview_left"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/textview_calendar_title" >
@@ -86,8 +87,8 @@
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"/>
 
-            <ImageButton
-                android:id="@+id/imagebutton_calendar_changedate"
+            <ImageView
+                android:id="@+id/imageView_calendar_changedate"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:background="@android:color/transparent"

--- a/app/src/main/res/layout/activity_setting.xml
+++ b/app/src/main/res/layout/activity_setting.xml
@@ -170,7 +170,6 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginRight="@dimen/margin_settingchild_top"
-                android:layout_marginBottom="@dimen/margin_settingchild_top"
                 android:track="@drawable/selector_foregroundalert_switch"
                 app:layout_constraintBottom_toBottomOf="@+id/textview_foregroundalert_title"
                 app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
## #63 달력에서 동그라미 위치 고정
- **오늘날짜**로 고정시켰습니다.
- 기존에 동그라미 위치를 변경하기 위해 사용된 불필요한 변수와 코드를 지웠습니다.
    -> 새로운 버그가 생길까봐 조금 걱정은 됩니다. 하지만 동그라미 이외에서 사용되지 않는 부분이여서 문제는 없을 것 같습니다.
<br>

## #66 일요일 빨간색 적용
- 일요일이 검정색으로 떠서 빨간색으로 바꿔주었습니다.
<br>

## 별책부록
- 설정액티비티의 switch의 위치를 조정해주었습니다. (텍스트와 가운데 맞춤. 마진제거)