### PR TITLE
fix: 나중에 교체하기를 누르면 곧바로 알림이 울리던 문제 수정

### DIFF
--- a/app/src/main/java/com/naccoro/wask/preferences/AlarmPreferenceManager.java
+++ b/app/src/main/java/com/naccoro/wask/preferences/AlarmPreferenceManager.java
@@ -1,0 +1,16 @@
+package com.naccoro.wask.preferences;
+
+public class AlarmPreferenceManager {
+
+    private static final String PREF_KEY_IS_REPLACEMENT_LATER = "is_replacement_later";
+
+    private static final boolean DEFAULT_IS_REPLACEMENT_LATER = false;
+
+    public static void setIsReplacementLater(boolean isReplacementLater) {
+        SharedPreferenceManager.getInstance().setBoolean(PREF_KEY_IS_REPLACEMENT_LATER, isReplacementLater);
+    }
+
+    public static boolean getIsReplacementLater() {
+        return SharedPreferenceManager.getInstance().getBoolean(PREF_KEY_IS_REPLACEMENT_LATER, DEFAULT_IS_REPLACEMENT_LATER);
+    }
+}

--- a/app/src/main/java/com/naccoro/wask/receivers/AlarmReceiver.java
+++ b/app/src/main/java/com/naccoro/wask/receivers/AlarmReceiver.java
@@ -11,6 +11,7 @@ import androidx.core.app.NotificationManagerCompat;
 
 import com.naccoro.wask.R;
 import com.naccoro.wask.mock.MockDatabase;
+import com.naccoro.wask.preferences.AlarmPreferenceManager;
 import com.naccoro.wask.utils.AlarmUtil;
 import com.naccoro.wask.utils.NotificationUtil;
 
@@ -28,13 +29,19 @@ public class AlarmReceiver extends BroadcastReceiver {
 
         if (type != null) {
             MockDatabase.MockNotificationData data;
-            if (type.equals(AlarmUtil.REPLACEMENT_CYCLE_VALUE)) {
+//            if (type.equals(AlarmUtil.REPLACEMENT_CYCLE_VALUE)) {
+//
+//                data = MockDatabase.getReplacementCycleData(context);
+//            } else {
+//
+//                data = MockDatabase.getReplaceLaterData(context);
+//            }
 
-                data = MockDatabase.getReplacementCycleData(context);
-            } else {
+            //나중에 교체하기 알림은 끝이 난 걸로 저장
+            AlarmPreferenceManager.setIsReplacementLater(false);
 
-                data = MockDatabase.getReplaceLaterData(context);
-            }
+            //동일한 형상의 Notification
+            data = MockDatabase.getReplacementCycleData(context);
 
             showPushNotification(context, data);
         }

--- a/app/src/main/java/com/naccoro/wask/receivers/BootReceiver.java
+++ b/app/src/main/java/com/naccoro/wask/receivers/BootReceiver.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import androidx.core.content.ContextCompat;
 
 import com.naccoro.wask.notification.WaskService;
+import com.naccoro.wask.preferences.AlarmPreferenceManager;
 import com.naccoro.wask.preferences.SettingPreferenceManager;
 import com.naccoro.wask.replacement.model.Injection;
 import com.naccoro.wask.replacement.repository.ReplacementHistoryRepository;
@@ -26,19 +27,24 @@ public class BootReceiver extends BroadcastReceiver {
         if (intent.getAction().equals("android.intent.action.BOOT_COMPLETED")) {
             // Set the alarm here.
 
-            AlarmUtil.setReplacementCycleAlarm(context);
+            int period = getMaskPeriod(context);
 
-            AlarmUtil.setReplacementCycleAlarm(context);
+            //교체일자가 없다면 실행하지 말것
+            if (period < 0) {
+                return;
+            }
+
+            //나중에 교체하기 실행 중이었다면 나중에 교체하기 알람을 재조정
+            if (AlarmPreferenceManager.getIsReplacementLater()) {
+                AlarmUtil.setReplacementLaterAlarm(context, true);
+            } else {
+                //일반 교체하기 알람을 실행 중이었다면 알람을 재조정
+                AlarmUtil.setReplacementCycleAlarm(context);
+            }
 
             if (SettingPreferenceManager.getIsShowNotificationBar()) {
-                int period = getMaskPeriod(context);
-
-                //교체일자가 없다면 실행하지 말것
-                if (period > 0) {
-                    AlarmUtil.showForegroundService(context, getMaskPeriod(context));
-
-                    AlarmUtil.setForegroundAlarm(context);
-                }
+                AlarmUtil.showForegroundService(context, period);
+                AlarmUtil.setForegroundAlarm(context);
             }
         }
     }

--- a/app/src/main/java/com/naccoro/wask/receivers/ReplaceLaterReceiver.java
+++ b/app/src/main/java/com/naccoro/wask/receivers/ReplaceLaterReceiver.java
@@ -6,7 +6,6 @@ import android.content.Context;
 import android.content.Intent;
 
 import com.naccoro.wask.utils.AlarmUtil;
-import com.naccoro.wask.utils.DateUtils;
 
 public class ReplaceLaterReceiver extends BroadcastReceiver {
 
@@ -25,7 +24,6 @@ public class ReplaceLaterReceiver extends BroadcastReceiver {
         }
 
         //나중에 교체하기 알람 등록
-        AlarmUtil.setReplacementLaterAlarm(context);
+        AlarmUtil.setReplacementLaterAlarm(context, false);
     }
-
 }

--- a/app/src/main/java/com/naccoro/wask/receivers/ReplaceMaskReceiver.java
+++ b/app/src/main/java/com/naccoro/wask/receivers/ReplaceMaskReceiver.java
@@ -5,6 +5,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 
+import com.naccoro.wask.preferences.AlarmPreferenceManager;
 import com.naccoro.wask.preferences.SettingPreferenceManager;
 import com.naccoro.wask.replacement.model.Injection;
 import com.naccoro.wask.replacement.repository.ReplacementHistoryRepository;
@@ -44,7 +45,13 @@ public class ReplaceMaskReceiver extends BroadcastReceiver {
             public void onSuccess() {
 
                 //알람을 지운다.
-                AlarmUtil.cancelReplaceLaterAlarm(context);
+                if (AlarmUtil.isLaterAlarmExist(context)) {
+                    AlarmUtil.cancelReplaceLaterAlarm(context);
+                    AlarmPreferenceManager.setIsReplacementLater(false);
+                }
+                if (AlarmUtil.isCycleAlarmExist(context)) {
+                    AlarmUtil.cancelReplacementCycleAlarm(context);
+                }
 
                 //알람 재등록
                 AlarmUtil.setReplacementCycleAlarm(context);

--- a/app/src/main/java/com/naccoro/wask/setting/SettingActivity.java
+++ b/app/src/main/java/com/naccoro/wask/setting/SettingActivity.java
@@ -3,7 +3,6 @@ package com.naccoro.wask.setting;
 import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;
 import android.view.View;
-import android.widget.CompoundButton;
 import android.widget.Switch;
 import android.widget.TextView;
 import com.naccoro.wask.R;
@@ -44,6 +43,9 @@ public class SettingActivity extends AppCompatActivity
 
         //start()함수를 호출하여 초기 설정값을 불러옴
         presenter.start();
+
+        //영구 알림 스위치 리스너 초기화
+        initSwitchListener();
     }
 
     private void init() {
@@ -60,15 +62,13 @@ public class SettingActivity extends AppCompatActivity
 
         alertVisibleSwitch = findViewById(R.id.switch_foregroundalert);
 
-        alertVisibleSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-            @Override
-            public void onCheckedChanged(CompoundButton compoundButton, boolean isChecked) {
-                presenter.changeAlertVisibleSwitch(SettingActivity.this, isChecked);
-            }
-        });
-
         toolbar.setBackButton(() -> presenter.clickHomeButton());
         toolbar.setLeftSideTitle(getString(R.string.setting_title));
+    }
+
+    private void initSwitchListener() {
+        alertVisibleSwitch.setOnCheckedChangeListener((compoundButton, isChecked) ->
+                presenter.changeAlertVisibleSwitch(SettingActivity.this, isChecked));
     }
 
     @Override

--- a/app/src/main/java/com/naccoro/wask/setting/SettingPresenter.java
+++ b/app/src/main/java/com/naccoro/wask/setting/SettingPresenter.java
@@ -125,9 +125,11 @@ public class SettingPresenter implements SettingContract.Presenter {
     public void changeReplaceLaterValue(Context context, int laterValue) {
         SettingPreferenceManager.setDelayCycle(laterValue);
 
-        //Alarm 다시 설정
-        AlarmUtil.cancelReplacementCycleAlarm(context);
-        AlarmUtil.setReplacementLaterAlarm(context);
+        //나중에 교체하기 알람 중이었다면 재설정
+        if (AlarmUtil.isLaterAlarmExist(context)) {
+            AlarmUtil.cancelReplaceLaterAlarm(context);
+            AlarmUtil.setReplacementLaterAlarm(context, true);
+        }
 
         settingView.showReplaceLaterValue(laterValue);
     }

--- a/app/src/main/java/com/naccoro/wask/ui/main/MainPresenter.java
+++ b/app/src/main/java/com/naccoro/wask/ui/main/MainPresenter.java
@@ -143,8 +143,14 @@ public class MainPresenter implements MainContract.Presenter {
      * 등록되어 있는 알람을 종료하고 새로운 교체하기 알람을 등록한다.
      */
     private void setMaskReplaceNotification(Context context) {
-        //남아있던 alarm 을 종료한다.
-        AlarmUtil.cancelReplaceLaterAlarm(context);
+        //기본 교체하기 알람이 있었다면 제거
+        if (AlarmUtil.isCycleAlarmExist(context)) {
+            AlarmUtil.cancelReplacementCycleAlarm(context);
+
+        //나중에 교체하기 알림 중이었다면 제거
+        } else if (AlarmUtil.isLaterAlarmExist(context)) {
+            AlarmUtil.cancelReplaceLaterAlarm(context);
+        }
 
         showForegroundNotification(context);
         AlarmUtil.setReplacementCycleAlarm(context);

--- a/app/src/main/java/com/naccoro/wask/utils/AlarmUtil.java
+++ b/app/src/main/java/com/naccoro/wask/utils/AlarmUtil.java
@@ -9,12 +9,12 @@ import android.util.Log;
 import androidx.core.content.ContextCompat;
 
 import com.naccoro.wask.notification.WaskService;
+import com.naccoro.wask.preferences.AlarmPreferenceManager;
 import com.naccoro.wask.preferences.SettingPreferenceManager;
 import com.naccoro.wask.receivers.AlarmReceiver;
 import com.naccoro.wask.receivers.ForegroundReceiver;
 import com.naccoro.wask.replacement.model.Injection;
 import com.naccoro.wask.replacement.repository.ReplacementHistoryRepository;
-import com.naccoro.wask.setting.SettingActivity;
 
 import java.util.Calendar;
 
@@ -52,6 +52,8 @@ public class AlarmUtil {
             period = period > periodDelay ? period - periodDelay : 0;
         }
 
+        Log.d(TAG, "setReplacementCycleAlarm(): period: " + period);
+
         Calendar calendar = Calendar.getInstance();
         calendar.add(Calendar.DAY_OF_MONTH, period);
         calendar.set(Calendar.HOUR_OF_DAY, REPLACEMENT_CYCLE_START_HOUR); //오전 6시 알람
@@ -68,24 +70,38 @@ public class AlarmUtil {
     /**
      * 나중에 교체 주기 Alarm을 등록하는 함수
      */
-    public static void setReplacementLaterAlarm(Context context) {
+    public static void setReplacementLaterAlarm(Context context, boolean isReset) {
+
         //나중에 교체하기를 누르면 기존 교체 주기 알람은 제거
-        cancelReplacementCycleAlarm(context);
-
-        ReplacementHistoryRepository replacementHistoryRepository = Injection.replacementHistoryRepository(context);
-
-        int replaceDate = replacementHistoryRepository.getLastReplacement();
-
-        //사용자가 선택한 교체하기 period 를 가져온다.
-        //int period = SettingPreferenceManager.getDelayCycle();
-        int period = SettingPreferenceManager.getDelayCycle() + 1; //Fixme: period 를 하루 적게 가져옵니다. 임시로 + 1
-
-        Log.d("period", period + "");
-        //저장되어 있는 교체주기 알람 date가 오늘보다 얼마나 지났는지 체크한다.
-        if (replaceDate != -1) {
-            int periodDelay = DateUtils.calculateDateGapWithToday(replaceDate);
-            period = period > periodDelay ? period - periodDelay : 0;
+        if (isCycleAlarmExist(context)) {
+            cancelReplacementCycleAlarm(context);
         }
+
+        //기존 나중에 교체하기 알람도 있다면 제거
+        if (isLaterAlarmExist(context)) {
+            cancelReplaceLaterAlarm(context);
+        }
+
+        int period = SettingPreferenceManager.getDelayCycle();
+
+        //재조정이 필요한 경우에는 나중에 교체하기 주기와 오늘 날짜의 차이를 계산하여 세팅
+        if (isReset) {
+
+            ReplacementHistoryRepository replacementHistoryRepository = Injection.replacementHistoryRepository(context);
+
+            int replaceDate = replacementHistoryRepository.getLastReplacement();
+
+            //저장되어 있는 나중에 교체주기 알람 date가 오늘보다 얼마나 지났는지 체크한다.
+            if (replaceDate != -1) {
+                int periodDelay = DateUtils.calculateDateGapWithToday(replaceDate);
+                period = period > periodDelay ? period - periodDelay : 0;
+            }
+        } else {
+            //일반 세팅의 경우는 나중에 교체하기 알람이 설정됨을 기억
+            AlarmPreferenceManager.setIsReplacementLater(true);
+        }
+
+        Log.d(TAG, "setReplacementLaterAlarm(): period: " + period);
 
         Calendar calendar = Calendar.getInstance();
         calendar.add(Calendar.DAY_OF_MONTH, period);
@@ -94,7 +110,7 @@ public class AlarmUtil {
 
         Intent intent = new Intent(context, AlarmReceiver.class);
         intent.putExtra(ALERT_TYPE, REPLACE_LATER_VALUE);
-        PendingIntent alarmIntent = PendingIntent.getBroadcast(context, REQUEST_CODE_REPLACEMENT_CYCLE, intent, 0);
+        PendingIntent alarmIntent = PendingIntent.getBroadcast(context, REQUEST_CODE_REPLACE_LATER, intent, 0);
 
         //처음에 Notification 이 작동 후 며칠 단위로 작동할지
         setAlertManager(context, calendar, alarmIntent);
@@ -183,5 +199,20 @@ public class AlarmUtil {
 
         //Foreground 알람 삭제
         cancelForegroundAlarm(context);
+    }
+
+    public static boolean isCycleAlarmExist(Context context) {
+        return isAlarmExist(context, REQUEST_CODE_REPLACEMENT_CYCLE);
+    }
+
+    public static boolean isLaterAlarmExist(Context context) {
+        return isAlarmExist(context, REQUEST_CODE_REPLACE_LATER);
+    }
+
+    private static boolean isAlarmExist(Context context, int alarmId) {
+        Intent intent = new Intent(context, AlarmReceiver.class);
+        PendingIntent sender = PendingIntent.getBroadcast(context, alarmId, intent, PendingIntent.FLAG_NO_CREATE);
+
+        return sender != null;
     }
 }


### PR DESCRIPTION
Resolved: #73


### 1. `setReplacementLaterAlarm` 메서드 개선

나중에 교체하기 알람 세팅 로직

변경 전
- 다음 교체 시기 = 가장 최근 교체 날짜 + 설정되어 있는 나중에 교체하기 주기

변경 후
- 다음 교체 시기 = 현재 날짜 + 설정되어 있는 나중에 교체하기 주기

변경 전의 로직이 고정되어 있었기 때문에 나중에 교체하기 주기와 교체 주기가 모두 1일로 설정되어 있는 경우, 2일 째 사용일 때 교체 알람이 떴고, 나중에 교체하기를 누르면 1일 전 + 1일이 더해져 곧장 알람이 울렸던 것입니다. 따라서 변경 후 로직을 수행한다면 정상적으로 작동하게 됩니다.

그러나 폰이 재부팅되었거나. 설정 값을 변경했을 경우에는 변경 전 로직이 유효하여야 하므로 위 역할을 수행하던 `setReplacementLaterAlarm(Context context, boolean isReset)` 메서드에 `isReset` 파라미터를 더하여 주었습니다.

해당 파라미터가 `true` 인 경우에는 변경 전 로직을 그대로 수행합니다.

### 2. `AlarmPreferenceManager` 추가

폰이 재부팅되었을 때, 기존에 어떤 알람이 설정되어있었는지 알 수 없습니다. 그러나 교체 주기와 나중에 교체하기 주기는 상이할 수 있기 때문에 구분이 반드시 필요하여 어떤 알람이 설정되어있었는지를 파악하기 위한 `SharedPreference` 클래스를 생성하였습니다.
- `AlarmPreferenceManager.setIsReplacementLater(boolean isReplacementLater)`
- `AlarmPreferenceManager.getIsReplacementLater()`

재부팅 시 실행되는 `BroadcastReceiver` 에서 해당 값을 검사하여 기존에 설정된 알람을 재설정하도록 합니다.


### 3. `AlarmUtil.isAlarmExist()` 추가

교체하기를 누르거나 교체 주기, 나중에 교체하기 주기를 수정하는 경우에는 기존 알람을 제거하고 새롭게 알람을 적용하여야 합니다.

또한 나중에 교체하기 주기를 수정하는 경우에는, 일반 교체 알람을 수행 중일 때는 알람이 재조정되어서는 안됩니다.

따라서 현재 설정되어 있는 알람이 무엇인지 파악하고 상황에 따라 알람을 재조정하거나, 설정값만 바꾸도록 대처할 수 있게 해당 메서드를 사용하였습니다.

`AlarmPreferenceManager`와 용도가 겹치나 사실 이 메서드를 먼저 작성한 후, 재부팅 시 재설정 문제를 발견하여 별도로 추가하게 되었습니다.

그리고 아무래도 Preference에 접근하는 것 보다 이 방법이 조금 더 빠르지 않을까 하여 둘을 병합하지 않고 나누어 두었습니다. 의견 부탁드립니다.