### PR TITLE
fix: 교체한 날이 아닌데 교체하기 취소 다이얼로그가 뜨는 문제

### DIFF
--- a/app/src/main/java/com/naccoro/wask/ui/main/MainPresenter.java
+++ b/app/src/main/java/com/naccoro/wask/ui/main/MainPresenter.java
@@ -45,7 +45,7 @@ public class MainPresenter implements MainContract.Presenter {
         } else if (period > 1) {
 
             checkIsFirstReplacement();
-
+            WaskApplication.isChanged = false;
             mainView.showBadMainView();
             mainView.enableReplaceButton();
         } else {
@@ -168,7 +168,6 @@ public class MainPresenter implements MainContract.Presenter {
             isNoData = true;
             return 0;
         }
-
         return DateUtils.calculateDateGapWithToday(lastReplacement) + 1;
     }
 }


### PR DESCRIPTION
너무 단순한 논리 실수가 있었네요... 

교체한 당일에는 `WaskApplication.isChanged` 변수를 `true` 로 변경하고 있지만, 당일이 아닌 경우에는 `false` 로 초기화하지 않고 있었습니다.
더군다나  `WaskApplication.isChanged` 는 별도의 초기화 없이 선언만 되어 있어서 당일이 아닌 경우에도 반드시 초기화가 필요한 상태였습니다.
따라서 교체 버튼을 눌렀을 때 호출되는 로직에서 해당 변수를 따라 분기하게 되는데 `!WaskApplication.isChanged` 가 항상 `false` 값만 갖도록 되어있었습니다.
```java
public void changeMask(Context context) {
    if (!WaskApplication.isChanged) {
        //교체한 당일이 아닐 때 --> 항상 실행이 안되고 있음
        ....
    } else {
    // 교체한 당일뿐만 아니라 교체 기록이 있다면 언제든 이 로직이 수행됨 (교체 취소 다이얼로그)
    .... 
    }
}
```

결론적으로 코드 한 줄만 추가하였습니다 ^^ (굉장한 수정을 한 척)
https://github.com/naccoro/WASK-Android/issues/92 
위 이슈에서는 교체 주기와 관련되어 꼬여있는 것 같다고 작성했으나 아니였네요 ㅎㅎ 다행입니다. 해결!