### PR TITLE
fix: 포그라운드 노티피케이션이 매일 자정 갱신되지 않는 문제 해결

### DIFF
--- a/app/src/main/java/com/naccoro/wask/notification/ServiceUtil.java
+++ b/app/src/main/java/com/naccoro/wask/notification/ServiceUtil.java
@@ -1,0 +1,25 @@
+package com.naccoro.wask.notification;
+
+import android.content.Context;
+import android.content.Intent;
+
+import androidx.core.content.ContextCompat;
+
+import com.naccoro.wask.utils.AlarmUtil;
+
+public class ServiceUtil {
+    public static void showForegroundService(Context context, int maskPeriod) {
+        Intent service = new Intent(context, WaskService.class);
+
+        service.putExtra("maskPeriod", maskPeriod);
+        ContextCompat.startForegroundService(context, service);
+    }
+
+    public static void dismissForegroundService(Context context) {
+        Intent service = new Intent(context, WaskService.class);
+        context.stopService(service);
+
+        //Foreground 알람 삭제
+        AlarmUtil.cancelForegroundAlarm(context);
+    }
+}

--- a/app/src/main/java/com/naccoro/wask/receivers/BootReceiver.java
+++ b/app/src/main/java/com/naccoro/wask/receivers/BootReceiver.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 
 import androidx.core.content.ContextCompat;
 
+import com.naccoro.wask.notification.ServiceUtil;
 import com.naccoro.wask.notification.WaskService;
 import com.naccoro.wask.preferences.AlarmPreferenceManager;
 import com.naccoro.wask.preferences.SettingPreferenceManager;
@@ -43,7 +44,7 @@ public class BootReceiver extends BroadcastReceiver {
             }
 
             if (SettingPreferenceManager.getIsShowNotificationBar()) {
-                AlarmUtil.showForegroundService(context, period);
+                ServiceUtil.showForegroundService(context, period);
                 AlarmUtil.setForegroundAlarm(context);
             }
         }

--- a/app/src/main/java/com/naccoro/wask/receivers/ForegroundReceiver.java
+++ b/app/src/main/java/com/naccoro/wask/receivers/ForegroundReceiver.java
@@ -3,7 +3,9 @@ package com.naccoro.wask.receivers;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.util.Log;
 
+import com.naccoro.wask.notification.ServiceUtil;
 import com.naccoro.wask.preferences.SettingPreferenceManager;
 import com.naccoro.wask.replacement.model.Injection;
 import com.naccoro.wask.replacement.repository.ReplacementHistoryRepository;
@@ -12,6 +14,7 @@ import com.naccoro.wask.utils.DateUtils;
 
 
 public class ForegroundReceiver extends BroadcastReceiver {
+    private static final String TAG = "ForegroundReceiver";
 
     /**
      * Alarm이 동작했을 때 작동하는 리시버
@@ -21,14 +24,17 @@ public class ForegroundReceiver extends BroadcastReceiver {
 
         if (SettingPreferenceManager.getIsShowNotificationBar()) {
             int period = getMaskPeriod(context);
+            Log.d(TAG, "onReceive: period = " + period);
 
             //교체일자가 없다면 실행하지 말것
             if (period > 0) {
-                AlarmUtil.dismissForegroundService(context);
-                AlarmUtil.showForegroundService(context, getMaskPeriod(context));
+                ServiceUtil.dismissForegroundService(context);
+                ServiceUtil.showForegroundService(context, getMaskPeriod(context));
+                //다음 날 00시 Notification을 갱신하기 위하여 알람을 재등록
+                AlarmUtil.setForegroundAlarm(context);
             } else {
                 AlarmUtil.cancelForegroundAlarm(context);
-                AlarmUtil.dismissForegroundService(context);
+                ServiceUtil.dismissForegroundService(context);
             }
         }
     }

--- a/app/src/main/java/com/naccoro/wask/receivers/ReplaceMaskReceiver.java
+++ b/app/src/main/java/com/naccoro/wask/receivers/ReplaceMaskReceiver.java
@@ -5,6 +5,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 
+import com.naccoro.wask.notification.ServiceUtil;
 import com.naccoro.wask.preferences.AlarmPreferenceManager;
 import com.naccoro.wask.preferences.SettingPreferenceManager;
 import com.naccoro.wask.replacement.model.Injection;
@@ -75,11 +76,11 @@ public class ReplaceMaskReceiver extends BroadcastReceiver {
             int period = getMaskPeriod();
             if (period > 0) {
 
-                AlarmUtil.showForegroundService(context, period);
+                ServiceUtil.showForegroundService(context, period);
 
                 AlarmUtil.setForegroundAlarm(context);
             } else {
-                AlarmUtil.dismissForegroundService(context);
+                ServiceUtil.dismissForegroundService(context);
 
                 AlarmUtil.cancelForegroundAlarm(context);
             }

--- a/app/src/main/java/com/naccoro/wask/setting/SettingActivity.java
+++ b/app/src/main/java/com/naccoro/wask/setting/SettingActivity.java
@@ -10,6 +10,7 @@ import com.naccoro.wask.customview.WaskToolbar;
 import com.naccoro.wask.customview.datepicker.wheel.WheelRecyclerView;
 import com.naccoro.wask.customview.waskdialog.WaskDialog;
 import com.naccoro.wask.customview.waskdialog.WaskDialogBuilder;
+import com.naccoro.wask.notification.ServiceUtil;
 import com.naccoro.wask.utils.AlarmUtil;
 
 public class SettingActivity extends AppCompatActivity
@@ -165,7 +166,7 @@ public class SettingActivity extends AppCompatActivity
     @Override
     public void showForegroundAlert(int maskPeriod) {
 
-        AlarmUtil.showForegroundService(this, maskPeriod);
+        ServiceUtil.showForegroundService(this, maskPeriod);
 
         AlarmUtil.setForegroundAlarm(this);
     }
@@ -175,7 +176,7 @@ public class SettingActivity extends AppCompatActivity
      */
     @Override
     public void dismissForegroundAlert() {
-        AlarmUtil.dismissForegroundService(this);
+        ServiceUtil.dismissForegroundService(this);
     }
 
     @Override

--- a/app/src/main/java/com/naccoro/wask/ui/calendar/CalendarAdapter.java
+++ b/app/src/main/java/com/naccoro/wask/ui/calendar/CalendarAdapter.java
@@ -9,6 +9,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import com.naccoro.wask.WaskApplication;
+import com.naccoro.wask.notification.ServiceUtil;
 import com.naccoro.wask.preferences.SettingPreferenceManager;
 import com.naccoro.wask.replacement.repository.ReplacementHistoryRepository;
 import com.naccoro.wask.utils.AlarmUtil;
@@ -195,11 +196,11 @@ public class CalendarAdapter extends RecyclerView.Adapter<CalendarAdapter.Calend
             WaskApplication.isChanged = period == 1;
 
             if (period > 0) {
-                AlarmUtil.showForegroundService(context, period);
+                ServiceUtil.showForegroundService(context, period);
 
                 AlarmUtil.setForegroundAlarm(context);
             } else {
-                AlarmUtil.dismissForegroundService(context);
+                ServiceUtil.dismissForegroundService(context);
 
                 AlarmUtil.cancelForegroundAlarm(context);
             }

--- a/app/src/main/java/com/naccoro/wask/ui/main/MainPresenter.java
+++ b/app/src/main/java/com/naccoro/wask/ui/main/MainPresenter.java
@@ -4,6 +4,7 @@ package com.naccoro.wask.ui.main;
 import android.content.Context;
 
 import com.naccoro.wask.WaskApplication;
+import com.naccoro.wask.notification.ServiceUtil;
 import com.naccoro.wask.preferences.SettingPreferenceManager;
 import com.naccoro.wask.utils.AlarmUtil;
 import com.naccoro.wask.utils.DateUtils;
@@ -130,10 +131,10 @@ public class MainPresenter implements MainContract.Presenter {
         if (SettingPreferenceManager.getIsShowNotificationBar()) {
             int period = getMaskPeriod();
             if (period > 0) {
-                AlarmUtil.showForegroundService(context, period);
+                ServiceUtil.showForegroundService(context, period);
                 AlarmUtil.setForegroundAlarm(context);
             } else {
-                AlarmUtil.dismissForegroundService(context);
+                ServiceUtil.dismissForegroundService(context);
                 AlarmUtil.cancelForegroundAlarm(context);
             }
         }


### PR DESCRIPTION
## 문제점 진단
https://github.com/naccoro/WASK-Android/issues/91

기존에는 아래와 같은 메서드로 두 가지의 알람을 세팅하고 있었습니다.
1. 매일 자정 Foreground Notification의 내용 갱신
2. 교체 주기 당일 혹은 그 이후 매일 09시 교체 권장의 일회성 Notification push

```java
private static void setAlertManager(Context context, Calendar calendar, PendingIntent alarmIntent, Boolean isRepeat) {
        calendar.set(Calendar.MINUTE, 0);
        calendar.set(Calendar.SECOND, 0);

        AlarmManager alarmManager;
        alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
        //처음 Calendar 날짜에 AlertManager가 작동되고 이후 하루마다 작동됩니다.
        alarmManager.setInexactRepeating(AlarmManager.RTC_WAKEUP, calendar.getTimeInMillis(),
                AlarmManager.INTERVAL_DAY, alarmIntent);

        Log.d(TAG, "setAlertManager: " + calendar.get(Calendar.YEAR) + "." + (calendar.get(Calendar.MONTH) + 1) + "." + calendar.get(Calendar.DAY_OF_MONTH));
    }
```

위 두 가지 알람 모두 사용자와의 특별한 상호작용(교체하기 혹은 나중에 교체하기 기능 수행, 사용 일자 알림 끄기 등)이 없는 한 동일한 시간에 매일 알람이 반복되어야한다는 특징이 있습니다.
따라서 `alarmManager.setInexactRepeating()` 메서드를 활용하여 알람을 등록하고 있었고, 정확한 일자에 알람이 등록되었는지 로그로 확인할 수 있었습니다.

그러나 (2) 에 해당하는 알람은 매일 정상적으로 작동되어 `BroadcastReceiver`가 이를 수신하고 Notification을 띄웠으나, (1) 에 해당하는 알람은 1~2번 정상 작동한 후 더이상 트리거되지 않음을 확인하였습니다.

### `BroadcastReceiver` 로직의 차이?
동일한 메서드로 알람을 세팅하기 때문에 (2)의 경우에는 `BroadcastReceiver` 에서 알람을 수신하고 수행하는 처리 로직이 (1)에 비해 비교적 무거워 OS에 의해 Kill 당하는 것은 아닌가 의심하였으나 각종 구글링을 통해서도 아무런 관련 근거를 찾을 수 없었습니다.

### Doze mode
다음으로 의심한 부분은 도즈모드였습니다. 도즈모드란 안드로이드 6.0 이상부터 추가된 기능으로 쉽게 말해 절전모드와 비슷한 기능입니다.
배터리 충전 중이 아니고 제 자리에 가만히 놓여진 채 계속해서 화면이 꺼진 상태였다면 도즈모드에 진입합니다. 이 모드에서는 다음과 같은 제약이 발생합니다.
1. 네트워크 액세스가 정지됩니다.
2. 시스템에서 `wake lock`을 무시합니다.
3. 표준 `AlarmManager` 알람이 다음 유지보수 기간까지 지연됩니다.
    a. Doze 모드에서도 실행되는 알람을 설정해야 하는 경우 `setAndAllowWhileIdle()` 또는 `setExactAndAllowWhileIdle()`를 사용합니다.
4. `setAlarmClock()`로 설정된 알람은 정상적으로 실행됩니다. 시스템에서 해당 알람이 실행되기 직전에 Doze 모드를 종료합니다.
5. 시스템에서 Wi-Fi 검색을 수행하지 않습니다.
6. 시스템에서 동기화 어댑터 실행을 허용하지 않습니다.
7. 시스템에서 `JobScheduler` 실행을 허용하지 않습니다.

혹시 알람이 작동하려는 자정에 하필 도즈모드에 진입한 상태였다면, 위 (3) 에 해당하는 제약 때문에 알람 작동이 지연되고, 운이 좋지 않게 알람이 무시당하는 것은 아닐까라는 생각을 하였습니다. 물론 알람이 무시된다는 내용은 찾아볼 수 없으므로 확실하지는 않았습니다.

하지만 위에 나온 `alarmManager.setAndAllowWhileIdle()` 메서드를 사용하여 자정 알람을 세팅하였고, 해당 알람을 수신한 `BroadcastReceiver` 에서 다음 날 자정으로 새롭게 알람을 맞추는 식으로 로직을 변경해보았습니다.
```java
public class ForegroundReceiver extends BroadcastReceiver {
    ...
    @Override
    public void onReceive(Context context, Intent intent) {

        if (SettingPreferenceManager.getIsShowNotificationBar()) {
            ...
            if (period > 0) {
                ...
                //다음 날 00시 Notification을 갱신하기 위하여 알람을 재등록
                AlarmUtil.setForegroundAlarm(context);
        ...
}
```

확실한 의심은 아니었으나, 이 처럼 수정하니 문제없이 자정에 Notification 이 갱신되는 결과를 얻게 되었습니다.
우선은 이와 같은 방법으로 문제점을 임시 해결해야할 것 같습니다 !

+++ 그리고 `ForegroundService` 를 띄우고 없애는 로직 (`showForegroundService(Context context, int maskPeriod)`, `dismissForegroundService(Context context)`) 이 `AlarmUtil` 에 포함되어 있었으나 분류가 올바르지 못하다고 판단하여 `ServiceUtil` 클래스를 생성하고 여기에 옮겨두었습니다.