### PR TITLE
feat: DatePresenter 뷰 생성 및 대체

### DIFF
--- a/app/src/main/java/com/naccoro/wask/customview/DatePresenter.java
+++ b/app/src/main/java/com/naccoro/wask/customview/DatePresenter.java
@@ -1,0 +1,184 @@
+package com.naccoro.wask.customview;
+
+import android.content.Context;
+import android.graphics.Color;
+import android.util.AttributeSet;
+import android.util.TypedValue;
+import android.view.Gravity;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
+
+import com.naccoro.wask.R;
+import com.naccoro.wask.ui.calendar.Date;
+import com.naccoro.wask.utils.MetricsUtil;
+
+import java.text.DateFormatSymbols;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.Locale;
+
+/**
+ * <YYYY년 MM월>, <MMMM YYYY> 형식으로 연도와 월을 보여주는 뷰
+ * 설정된 언어에 따라 형식이 맞추어짐
+ * @author seonggyu
+ * @since 2020.12.05
+ */
+public class DatePresenter extends LinearLayout {
+    private static final float TEXT_SIZE = 14f;
+    private static final float PADDING_ARROW_IMAGE = 11f;
+
+    private boolean isKoreanDataType;
+    private TextView yearText;
+    private TextView monthText;
+    private ImageView arrowImage;
+    private Date date;
+
+    private DateFormatSymbols dateFormatSymbols;
+
+    public DatePresenter(Context context) {
+        super(context);
+        init();
+    }
+
+    public DatePresenter(Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+        init();
+    }
+
+    public DatePresenter(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init();
+    }
+
+    public DatePresenter(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        init();
+    }
+
+    //뷰 초기화
+    private void init() {
+        //부모 레이아웃의 속성 설정
+        setLayoutParams(new LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT));
+        setGravity(Gravity.CENTER);
+        setOrientation(LinearLayout.HORIZONTAL);
+        //부모 클릭시 애니메이션 효과 설정
+        setClickEffect();
+
+        //오늘 날짜로 초기화
+        initDate();
+        //자식 뷰 초기화
+        initChildViews();
+        //설정 언어에 맞게 어순과 형식 변경
+        setLocaleDateType();
+    }
+
+    //설정 언어에 맞게 어순과 형식 변경
+    private void setLocaleDateType() {
+        //설정된 국가 가져오기
+        Locale locale = getResources().getConfiguration().locale;
+        //국가로부터 언어 가져오기
+        String language = locale.getLanguage();
+        if (language.equals("en")) { //영어로 설정된 경우
+            setEnglishDateType();
+        } else { //그 외
+            setKoreanDateType();
+        }
+    }
+
+    //오늘 날짜로 date 초기화
+    private void initDate() {
+        GregorianCalendar calendar = new GregorianCalendar();
+        date = new Date(calendar.get(Calendar.YEAR),
+                calendar.get(Calendar.MONTH), calendar.get(Calendar.DAY_OF_MONTH));
+    }
+
+    //자식 뷰 생성 및 속성 초기화
+    private void initChildViews() {
+        yearText = new TextView(getContext());
+        monthText = new TextView(getContext());
+        arrowImage = new ImageView(getContext());
+        setAttributesToTextView(yearText);
+        setAttributesToTextView(monthText);
+        setAttributesToImageView();
+    }
+
+    //이미지뷰 속성 초기화
+    private void setAttributesToImageView() {
+        int padding = (int) MetricsUtil.convertDpToPixel(PADDING_ARROW_IMAGE, getContext());
+        arrowImage.setPadding(padding, padding, padding, padding);
+        arrowImage.setImageDrawable(
+                ContextCompat.getDrawable(getContext(), R.drawable.ic_calendar_changedate));
+        arrowImage.setBackgroundColor(Color.TRANSPARENT);
+    }
+
+    //텍스트뷰 속성 초기화
+    private void setAttributesToTextView(TextView textView) {
+        textView.setTextSize(TEXT_SIZE);
+        textView.setTextColor(ContextCompat.getColor(getContext(), R.color.waskGrayFont));
+    }
+
+    //클릭 애니메이션 효과 설정
+    private void setClickEffect() {
+        TypedValue outValue = new TypedValue();
+        getContext().getTheme().resolveAttribute(android.R.attr.selectableItemBackground,
+                outValue, true);
+        setBackgroundResource(outValue.resourceId);
+    }
+
+    //영어 형식으로 어순 및 형식 변경
+    private void setEnglishDateType() {
+        removeAllViews();
+        addView(monthText);
+        addView(yearText);
+        addView(arrowImage);
+        setEnglishDate();
+        isKoreanDataType = false;
+    }
+
+    //한국어 형식으로 어순 및 형식 변경
+    private void setKoreanDateType() {
+        removeAllViews();
+        addView(yearText);
+        addView(monthText);
+        addView(arrowImage);
+        setKoreanDate();
+        isKoreanDataType = true;
+    }
+
+    //한국어 형식으로 날짜 적용
+    private void setKoreanDate() {
+        yearText.setText(date.getYear() + getContext().getString(R.string.calendar_year) + " ");
+        monthText.setText(date.getMonth() + 1 + getContext().getString(R.string.calendar_month));
+    }
+
+    //영어 형식으로 날짜 적용
+    private void setEnglishDate() {
+        yearText.setText(String.valueOf(date.getYear()));
+        monthText.setText(getMonthName(date.getMonth()) + " ");
+    }
+
+    //영어인 경우, 월의 이름(November, December 등) 가져오기
+    private String getMonthName(int month) {
+        if (dateFormatSymbols == null) {
+            dateFormatSymbols = new DateFormatSymbols();
+        }
+        return dateFormatSymbols.getMonths()[month];
+    }
+
+    /**
+     * 해당 뷰에서 보여주고 싶은 연도와 월을 설정
+     * @param date 설정할 연도와 월을 포함한 Date 객체
+     */
+    public void setDate(Date date) {
+        this.date = date;
+        if (isKoreanDataType) {
+            setKoreanDate();
+        } else {
+            setEnglishDate();
+        }
+    }
+}

--- a/app/src/main/java/com/naccoro/wask/ui/calendar/CalendarActivity.java
+++ b/app/src/main/java/com/naccoro/wask/ui/calendar/CalendarActivity.java
@@ -6,6 +6,7 @@ import android.widget.Switch;
 import android.widget.TextView;
 
 import com.naccoro.wask.R;
+import com.naccoro.wask.customview.DatePresenter;
 import com.naccoro.wask.customview.WaskToolbar;
 import com.naccoro.wask.customview.datepicker.DatePickerDialogFragment;
 import com.naccoro.wask.replacement.model.Injection;
@@ -15,15 +16,13 @@ import java.util.ArrayList;
 import java.util.GregorianCalendar;
 
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 public class CalendarActivity extends AppCompatActivity
         implements View.OnClickListener, CalendarContract.View {
 
-    TextView calendarDateTextView;
-    ConstraintLayout changeDateConstraintLayout;
+    DatePresenter changeDatePresenter;
     Switch modifyModeSwitch;
     TextView modifyModeTextView;
 
@@ -51,22 +50,21 @@ public class CalendarActivity extends AppCompatActivity
     }
 
     private void initView() {
-        calendarDateTextView = findViewById(R.id.textview_calendar_date);
-        changeDateConstraintLayout = findViewById(R.id.constraintlayout_changedate);
+        changeDatePresenter = findViewById(R.id.datepresenter_changedate);
         modifyModeSwitch = findViewById(R.id.switch_calendar_modify);
         modifyModeTextView = findViewById(R.id.textview_calendar_modify);
         recyclerView = findViewById(R.id.recyclerview_calender);
 
         toolbar = findViewById(R.id.wasktoolbar_calendar);
 
-        changeDateConstraintLayout.setOnClickListener(this);
+        changeDatePresenter.setOnClickListener(this);
 
         // 스위치 모드 변경
         modifyModeSwitch.setOnCheckedChangeListener((compoundButton, isChecked) -> presenter.changeModifyMode(isChecked, calendarAdapter));
 
         // calendar 관련 설정
         initSelectDate();
-        presenter.changeCalendarDateTextView(selectDate);
+        changeDatePresenter.setDate(selectDate);
         presenter.changeCalendarList(selectDate);
 
         // 리사이클러뷰 초기화
@@ -114,12 +112,13 @@ public class CalendarActivity extends AppCompatActivity
     @Override
     public void onClick(View view) {
         switch (view.getId()) {
-            case R.id.constraintlayout_changedate: // (0000년 00월) 버튼 클릭 시
+            case R.id.datepresenter_changedate: // (0000년 00월) 버튼 클릭 시
                 DatePickerDialogFragment.newInstance().
                         setOnDateChangedListener((year, month, day) -> {
                             selectDate.setDate(year, month, day);
                             presenter.clickChangeDateButton(selectDate);
                             calendarAdapter.setCalendarList(dateList);
+                            showCalendarDateTextView();
                         })
                         .setDate(selectDate.getYear(), selectDate.getMonth(), selectDate.getDay())
                         .show(getSupportFragmentManager(), "dialog");
@@ -131,9 +130,8 @@ public class CalendarActivity extends AppCompatActivity
      * date picker에서 설정된 날짜(selectDate)기준으로 0000년 00월 표시 설정
      */
     @Override
-    public void showCalendarDateTextView(int month) {
-        calendarDateTextView.setText(selectDate.getYear() + getString(R.string.calendar_year)
-                + month + getString(R.string.calendar_month));
+    public void showCalendarDateTextView() {
+        changeDatePresenter.setDate(selectDate);
     }
 
     @Override
@@ -145,63 +143,5 @@ public class CalendarActivity extends AppCompatActivity
     public void finish() {
         super.finish();
         overridePendingTransition(R.anim.slide_activity_fadein, R.anim.slide_activity_fadeout);
-    }
-
-    /**
-     * SelectDate를 저장하기 위한 클래스 (year, month, day 저장)
-     */
-    public static class Date {
-        private int year;
-        private int month;
-        private int day;
-
-        public Date(int year, int month, int day) {
-            this.year = year;
-            this.month = month;
-            this.day = day;
-        }
-
-        public void setDate(int year, int month, int day) {
-            this.year = year;
-            this.month = month;
-            this.day = day;
-        }
-
-        public int getYear() {
-            return year;
-        }
-
-        public void setYear(int year) {
-            this.year = year;
-        }
-
-        public int getMonth() {
-            return month;
-        }
-
-        public void setMonth(int month) {
-            this.month = month;
-        }
-
-        public int getDay() {
-            return day;
-        }
-
-        public void setDay(int day) {
-            this.day = day;
-        }
-
-        public boolean isSameDate(GregorianCalendar cal) {
-            if (cal.get(Calendar.YEAR) != year) {
-                return false;
-            }
-            if (cal.get(Calendar.MONTH) != month) {
-                return false;
-            }
-            if (cal.get(Calendar.DATE) != day) {
-                return false;
-            }
-            return true;
-        }
     }
 }

--- a/app/src/main/java/com/naccoro/wask/ui/calendar/CalendarAdapter.java
+++ b/app/src/main/java/com/naccoro/wask/ui/calendar/CalendarAdapter.java
@@ -14,7 +14,6 @@ import com.naccoro.wask.preferences.SettingPreferenceManager;
 import com.naccoro.wask.replacement.repository.ReplacementHistoryRepository;
 import com.naccoro.wask.utils.AlarmUtil;
 import com.naccoro.wask.utils.DateUtils;
-import com.naccoro.wask.ui.calendar.CalendarActivity.Date;
 
 import java.util.ArrayList;
 import java.util.Calendar;

--- a/app/src/main/java/com/naccoro/wask/ui/calendar/CalendarContract.java
+++ b/app/src/main/java/com/naccoro/wask/ui/calendar/CalendarContract.java
@@ -1,12 +1,11 @@
 package com.naccoro.wask.ui.calendar;
 
 import java.util.ArrayList;
-import com.naccoro.wask.ui.calendar.CalendarActivity.Date;
 
 public interface CalendarContract {
     interface View {
         void finishCalendarView();
-        void showCalendarDateTextView(int month);
+        void showCalendarDateTextView();
         void initCalendarList(ArrayList<CalendarItem> calendarItems);
         void showModifyModeTextView(boolean isChecked);
     }
@@ -15,7 +14,6 @@ public interface CalendarContract {
         void clickBackButton();
         void clickChangeDateButton(Date selectDate);
         void changeCalendarList(Date selectDate);
-        void changeCalendarDateTextView(Date selectDate);
         void changeModifyMode(boolean isChecked, CalendarAdapter calendarAdapter);
     }
 }

--- a/app/src/main/java/com/naccoro/wask/ui/calendar/CalendarModel.java
+++ b/app/src/main/java/com/naccoro/wask/ui/calendar/CalendarModel.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.GregorianCalendar;
 import java.util.List;
 
-import com.naccoro.wask.ui.calendar.CalendarActivity.Date;
 import com.naccoro.wask.replacement.repository.ReplacementHistoryRepository;
 import com.naccoro.wask.utils.DateUtils;
 

--- a/app/src/main/java/com/naccoro/wask/ui/calendar/CalendarPresenter.java
+++ b/app/src/main/java/com/naccoro/wask/ui/calendar/CalendarPresenter.java
@@ -1,6 +1,5 @@
 package com.naccoro.wask.ui.calendar;
 
-import com.naccoro.wask.ui.calendar.CalendarActivity.Date;
 import com.naccoro.wask.replacement.repository.ReplacementHistoryRepository;
 
 public class CalendarPresenter implements CalendarContract.Presenter {
@@ -30,7 +29,6 @@ public class CalendarPresenter implements CalendarContract.Presenter {
     @Override
     public void clickChangeDateButton(Date selectDate) {
         changeCalendarList(selectDate);
-        changeCalendarDateTextView(selectDate);
     }
 
     /**
@@ -40,19 +38,7 @@ public class CalendarPresenter implements CalendarContract.Presenter {
      */
     @Override
     public void changeCalendarList(Date selectDate) {
-
         calendarModel.updateCalendarList(selectDate, dateList -> calendarView.initCalendarList(dateList));
-    }
-
-    /**
-     * 0000년 00월 표시
-     *
-     * @param selectDate
-     */
-    @Override
-    public void changeCalendarDateTextView(Date selectDate) {
-        int month = selectDate.getMonth() + 1;
-        calendarView.showCalendarDateTextView(month);
     }
 
     /**

--- a/app/src/main/java/com/naccoro/wask/ui/calendar/Date.java
+++ b/app/src/main/java/com/naccoro/wask/ui/calendar/Date.java
@@ -1,0 +1,62 @@
+package com.naccoro.wask.ui.calendar;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+
+/**
+ * SelectDate를 저장하기 위한 클래스 (year, month, day 저장)
+ */
+public class Date {
+    private int year;
+    private int month;
+    private int day;
+
+    public Date(int year, int month, int day) {
+        this.year = year;
+        this.month = month;
+        this.day = day;
+    }
+
+    public void setDate(int year, int month, int day) {
+        this.year = year;
+        this.month = month;
+        this.day = day;
+    }
+
+    public int getYear() {
+        return year;
+    }
+
+    public void setYear(int year) {
+        this.year = year;
+    }
+
+    public int getMonth() {
+        return month;
+    }
+
+    public void setMonth(int month) {
+        this.month = month;
+    }
+
+    public int getDay() {
+        return day;
+    }
+
+    public void setDay(int day) {
+        this.day = day;
+    }
+
+    public boolean isSameDate(GregorianCalendar cal) {
+        if (cal.get(Calendar.YEAR) != year) {
+            return false;
+        }
+        if (cal.get(Calendar.MONTH) != month) {
+            return false;
+        }
+        if (cal.get(Calendar.DATE) != day) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/app/src/main/res/layout/activity_calendar.xml
+++ b/app/src/main/res/layout/activity_calendar.xml
@@ -37,7 +37,7 @@
             android:textColor="@color/waskGrayFont"
             android:textSize="17dp"
             android:textStyle="bold"
-            app:layout_constraintBottom_toTopOf="@+id/constraintlayout_changedate"
+            app:layout_constraintBottom_toTopOf="@+id/datepresenter_changedate"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@id/constraintlayout_content" />
 
@@ -65,40 +65,15 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@id/textview_calendar_title" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/constraintlayout_changedate"
+        <com.naccoro.wask.customview.DatePresenter
+            android:id="@+id/datepresenter_changedate"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:foreground="?android:selectableItemBackground"
             android:paddingVertical="@dimen/padding_calendar_changebutton"
             android:paddingEnd="@dimen/padding_calendar_changebutton"
-            android:layout_marginLeft="@dimen/margin_calendar_textview_left"
+            android:layout_marginStart="@dimen/margin_calendar_textview_left"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/textview_calendar_title" >
-
-            <TextView
-                android:id="@+id/textview_calendar_date"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                tools:text="2020년 12월"
-                android:textColor="@color/waskGrayFont"
-                android:textSize="14dp"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent"/>
-
-            <ImageView
-                android:id="@+id/imageView_calendar_changedate"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:background="@android:color/transparent"
-                android:src="@drawable/ic_calendar_changedate"
-                android:padding="@dimen/padding_calendar_changebutton"
-                app:layout_constraintStart_toEndOf="@id/textview_calendar_date"
-                app:layout_constraintTop_toTopOf="@id/textview_calendar_date"
-                app:layout_constraintBottom_toBottomOf="@id/textview_calendar_date" />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
+            app:layout_constraintTop_toBottomOf="@+id/textview_calendar_title"/>
 
         <LinearLayout
             android:id="@+id/linearLayout"
@@ -109,7 +84,7 @@
             android:layout_marginTop="@dimen/margin_week_top"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/constraintlayout_changedate">
+            app:layout_constraintTop_toBottomOf="@+id/datepresenter_changedate">
 
             <TextView
                 android:id="@+id/textview_sunday"

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -43,7 +43,7 @@
     <string name="notification_foreground_action">WASK 열기</string>
 
     <string name="toast_replacement">교체되었습니다</string>
-    <string name="calendar_year">년 </string>
+    <string name="calendar_year">년</string>
     <string name="calendar_month">월</string>
     <string name="calendar_history_of_replacement">마스크 교체 기록</string>
     <string name="calendar_edit_mode">수정모드</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,7 +44,7 @@
 
     <string name="toast_replacement">교체되었습니다</string>
 
-    <string name="calendar_year">년 </string>
+    <string name="calendar_year">년</string>
     <string name="calendar_month">월</string>
     <string name="calendar_history_of_replacement">마스크 교체 기록</string>
     <string name="calendar_edit_mode">수정모드</string>


### PR DESCRIPTION
<img width="300" src="https://user-images.githubusercontent.com/57310034/101236767-102b9800-3717-11eb-96fd-c014d4901723.png">
여기에 해당하는 부분을 커스텀 뷰로 묶은 다음, 기존 로직에서 날짜가 변경될 때마다 `.setDate(Date date)` 만 호출하면 되도록 하였습니다.
기본 비즈니스 로직에는 변화가 없습니다 !

새로 만든 커스텀뷰는 주석을 자세히 달아둬서 슥 읽으면 이해가 가실 겁니다.

## 결과
<img width="300" src="https://user-images.githubusercontent.com/57310034/101237154-d0b27b00-3719-11eb-8ae7-7788d4134ec0.png"/>  


사실 커스텀뷰가 꼭 필요하진 않았지만 그냥 해보고싶었습니다...ㅎ