### PR TITLE
feat: PeriodPresenter 커스텀뷰를 활용한 교체 주기 단수/복수 이슈 해결

### DIFF
--- a/app/src/main/java/com/naccoro/wask/customview/PeriodPresenter.java
+++ b/app/src/main/java/com/naccoro/wask/customview/PeriodPresenter.java
@@ -1,0 +1,117 @@
+package com.naccoro.wask.customview;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.util.AttributeSet;
+
+import androidx.annotation.Nullable;
+
+import com.naccoro.wask.R;
+
+import java.util.Locale;
+
+public class PeriodPresenter extends androidx.appcompat.widget.AppCompatTextView {
+    private static final int REPLACEMENT_CYCLE = 0;
+    private static final int SNOOZE_REMINDER = 1;
+    private static final int CURRENT_USING = 2;
+
+    private int format;
+    private boolean isKoreanType;
+
+    public PeriodPresenter(Context context) {
+        super(context);
+        init(null);
+    }
+
+    public PeriodPresenter(Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+        init(attrs);
+    }
+
+    public PeriodPresenter(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init(attrs);
+    }
+
+    private void init(@Nullable AttributeSet attrs) {
+        if (attrs != null) {
+            TypedArray typedArray = getContext().getTheme()
+                    .obtainStyledAttributes(attrs, R.styleable.PeriodPresenter, 0, 0);
+            if (typedArray.hasValue(R.styleable.PeriodPresenter_type)) {
+                format = typedArray.getInt(R.styleable.PeriodPresenter_type, 0);
+            }
+        } else {
+            format = REPLACEMENT_CYCLE;
+        }
+        setLocaleDateType();
+    }
+
+    //설정 언어에 맞게 어순과 형식 변경
+    private void setLocaleDateType() {
+        //설정된 국가 가져오기
+        Locale locale = getResources().getConfiguration().locale;
+        //국가로부터 언어 가져오기
+        String language = locale.getLanguage();
+
+        isKoreanType = !language.equals("en");
+    }
+
+    public void setPeriod(int period) {
+        StringBuilder builder = new StringBuilder()
+        .append(getPrefix())
+                .append(getPeriod(period))
+                .append(getSuffix(period));
+
+        setText(builder.toString());
+    }
+
+    private String getPrefix() {
+        if (isKoreanType) {
+            return "";
+        } else {
+            switch (format) {
+                case REPLACEMENT_CYCLE :
+                    return getContext().getString(R.string.period_prefix_cycle);
+                case SNOOZE_REMINDER :
+                    return getContext().getString(R.string.period_prefix_snooze);
+                case CURRENT_USING :
+                    return "";
+                default:
+                    throw new IllegalArgumentException("format value must be in 0 ~ 2");
+            }
+        }
+    }
+
+    private String getPeriod(int period) {
+        if (format == CURRENT_USING) {
+            return "";
+        }
+        if (isKoreanType) {
+            return period + "";
+        } else {
+            return period == 1 ? "" : period + "";
+        }
+    }
+
+    private String getSuffix(int period) {
+        if (isKoreanType) {
+            switch (format) {
+                case REPLACEMENT_CYCLE :
+                    return getContext().getString(R.string.period_suffix_cycle);
+                case SNOOZE_REMINDER :
+                    return getContext().getString(R.string.period_suffix_snooze);
+                case CURRENT_USING :
+                    return getContext().getString(R.string.period_suffix_current_using);
+                default:
+                    throw new IllegalArgumentException("format value must be in 0 ~ 2");
+            }
+        } else {
+            String suffix = period == 1 ? getContext().getString(R.string.period_suffix_singular)
+                    : getContext().getString(R.string.period_suffix_plural);
+            if (format == CURRENT_USING) {
+                suffix += getContext().getString(R.string.period_suffix_used);
+            }
+            return suffix;
+        }
+    }
+}

--- a/app/src/main/java/com/naccoro/wask/customview/PeriodPresenter.java
+++ b/app/src/main/java/com/naccoro/wask/customview/PeriodPresenter.java
@@ -10,6 +10,11 @@ import com.naccoro.wask.R;
 
 import java.util.Locale;
 
+/**
+ * 한국어/영어, 단수/복수, 주기 형태에 따른 문자열 조합 커스텀 뷰
+ * @author seonggyu
+ * @since 2020/12/06
+ */
 public class PeriodPresenter extends androidx.appcompat.widget.AppCompatTextView {
     private static final int REPLACEMENT_CYCLE = 0;
     private static final int SNOOZE_REMINDER = 1;
@@ -34,6 +39,7 @@ public class PeriodPresenter extends androidx.appcompat.widget.AppCompatTextView
     }
 
     private void init(@Nullable AttributeSet attrs) {
+        //format 초기화
         if (attrs != null) {
             TypedArray typedArray = getContext().getTheme()
                     .obtainStyledAttributes(attrs, R.styleable.PeriodPresenter, 0, 0);
@@ -43,6 +49,7 @@ public class PeriodPresenter extends androidx.appcompat.widget.AppCompatTextView
         } else {
             format = REPLACEMENT_CYCLE;
         }
+        //언어 초기화
         setLocaleDateType();
     }
 
@@ -56,6 +63,10 @@ public class PeriodPresenter extends androidx.appcompat.widget.AppCompatTextView
         isKoreanType = !language.equals("en");
     }
 
+    /**
+     * 주기 표현 메서드
+     * @param period 나타내고자하는 주기 값
+     */
     public void setPeriod(int period) {
         StringBuilder builder = new StringBuilder()
         .append(getPrefix())
@@ -65,6 +76,7 @@ public class PeriodPresenter extends androidx.appcompat.widget.AppCompatTextView
         setText(builder.toString());
     }
 
+    //접두사 결정
     private String getPrefix() {
         if (isKoreanType) {
             return "";
@@ -82,6 +94,7 @@ public class PeriodPresenter extends androidx.appcompat.widget.AppCompatTextView
         }
     }
 
+    //주기 표기 결정
     private String getPeriod(int period) {
         if (format == CURRENT_USING) {
             return "";
@@ -93,6 +106,7 @@ public class PeriodPresenter extends androidx.appcompat.widget.AppCompatTextView
         }
     }
 
+    //접미사 결정
     private String getSuffix(int period) {
         if (isKoreanType) {
             switch (format) {

--- a/app/src/main/java/com/naccoro/wask/setting/SettingActivity.java
+++ b/app/src/main/java/com/naccoro/wask/setting/SettingActivity.java
@@ -6,6 +6,7 @@ import android.view.View;
 import android.widget.Switch;
 import android.widget.TextView;
 import com.naccoro.wask.R;
+import com.naccoro.wask.customview.PeriodPresenter;
 import com.naccoro.wask.customview.WaskToolbar;
 import com.naccoro.wask.customview.datepicker.wheel.WheelRecyclerView;
 import com.naccoro.wask.customview.waskdialog.WaskDialog;
@@ -17,9 +18,9 @@ public class SettingActivity extends AppCompatActivity
         implements SettingContract.View, View.OnClickListener {
 
     //마스크 교체 주기
-    private TextView replacementCycleAlertLabel;
+    private PeriodPresenter replacementCycleAlertLabel;
     //나중에 교체하기
-    private TextView replaceLaterLabel;
+    private PeriodPresenter replaceLaterLabel;
     //푸시 알람
     private TextView pushAlertLabel;
     //포그라운드 서비스 알람
@@ -50,8 +51,8 @@ public class SettingActivity extends AppCompatActivity
     }
 
     private void init() {
-        replacementCycleAlertLabel = findViewById(R.id.textview_replacementcyclealert_body);
-        replaceLaterLabel = findViewById(R.id.textview_replacelater_body);
+        replacementCycleAlertLabel = findViewById(R.id.periodpresenter_replacementcyclealert_body);
+        replaceLaterLabel = findViewById(R.id.periodpresenter_replacelater_body);
         pushAlertLabel = findViewById(R.id.textview_pushalert_body);
         toolbar = findViewById(R.id.wasktoolbar_setting);
 
@@ -144,13 +145,13 @@ public class SettingActivity extends AppCompatActivity
     @Override
     public void showReplacementCycleValue(int cycleValue) {
         periodReplacementCycle = cycleValue;
-        replacementCycleAlertLabel.setText(cycleValue + getString(R.string.setting_day));
+        replacementCycleAlertLabel.setPeriod(cycleValue);
     }
 
     @Override
     public void showReplaceLaterValue(int laterValue) {
         periodReplaceLater = laterValue;
-        replaceLaterLabel.setText(laterValue + getString(R.string.setting_day));
+        replaceLaterLabel.setPeriod(laterValue);
     }
 
     @Override

--- a/app/src/main/java/com/naccoro/wask/ui/main/MainActivity.java
+++ b/app/src/main/java/com/naccoro/wask/ui/main/MainActivity.java
@@ -10,6 +10,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.naccoro.wask.R;
+import com.naccoro.wask.customview.PeriodPresenter;
 import com.naccoro.wask.ui.calendar.CalendarActivity;
 import com.naccoro.wask.customview.WaskToolbar;
 import com.naccoro.wask.customview.waskdialog.WaskDialogBuilder;
@@ -23,7 +24,7 @@ public class MainActivity extends AppCompatActivity
     ImageView emotionImageView;
     TextView cardMessageTextView;
     TextView usePeriodTextView;
-    TextView usePeriodMessageTextView;
+    PeriodPresenter usePeriodMessageTextView;
     TextView changeButton;
     WaskToolbar toolbar;
 
@@ -152,8 +153,8 @@ public class MainActivity extends AppCompatActivity
     }
 
     @Override
-    public void changeUsePeriodMessage() {
+    public void changeUsePeriodMessage(int period) {
         usePeriodTextView.setVisibility(View.VISIBLE);
-        usePeriodMessageTextView.setText(R.string.main_use_period_message);
+        usePeriodMessageTextView.setPeriod(period);
     }
 }

--- a/app/src/main/java/com/naccoro/wask/ui/main/MainActivity.java
+++ b/app/src/main/java/com/naccoro/wask/ui/main/MainActivity.java
@@ -46,7 +46,7 @@ public class MainActivity extends AppCompatActivity
         emotionImageView = findViewById(R.id.imageview_emotion);
         cardMessageTextView = findViewById(R.id.textview_card_message);
         usePeriodTextView = findViewById(R.id.textview_use_period);
-        usePeriodMessageTextView = findViewById(R.id.textview_use_period_message);
+        usePeriodMessageTextView = findViewById(R.id.periodpresenter_use_period_message);
         changeButton = findViewById(R.id.button_change);
         toolbar = findViewById(R.id.wasktoolbar_main);
 

--- a/app/src/main/java/com/naccoro/wask/ui/main/MainContract.java
+++ b/app/src/main/java/com/naccoro/wask/ui/main/MainContract.java
@@ -25,7 +25,7 @@ public interface MainContract {
 
         void showNoReplaceData();
 
-        void changeUsePeriodMessage();
+        void changeUsePeriodMessage(int period);
     }
 
     interface Presenter {

--- a/app/src/main/java/com/naccoro/wask/ui/main/MainPresenter.java
+++ b/app/src/main/java/com/naccoro/wask/ui/main/MainPresenter.java
@@ -19,8 +19,6 @@ public class MainPresenter implements MainContract.Presenter {
 
     private ReplacementHistoryRepository replacementHistoryRepository;
 
-    private boolean isNoData = true;
-
     MainContract.View mainView;
 
     MainPresenter(MainContract.View mainView, ReplacementHistoryRepository replacementHistoryRepository) {
@@ -44,14 +42,13 @@ public class MainPresenter implements MainContract.Presenter {
             mainView.showNoReplaceData();
             mainView.enableReplaceButton();
         } else if (period > 1) {
-
-            checkIsFirstReplacement();
+            setUsingPeriodMessage(period);
             WaskApplication.isChanged = false;
             mainView.showBadMainView();
             mainView.enableReplaceButton();
         } else {
             //교체한 당일
-            checkIsFirstReplacement();
+            setUsingPeriodMessage(period);
             WaskApplication.isChanged = true;
             mainView.showGoodMainView();
             mainView.disableReplaceButton();
@@ -59,13 +56,10 @@ public class MainPresenter implements MainContract.Presenter {
     }
 
     /**
-     * 첫 번째 교체인지 확인 후 멘트 변경
+     * 교체 일자에 따른 사용 메시지 변경
      */
-    private void checkIsFirstReplacement() {
-        if (isNoData) {
-            mainView.changeUsePeriodMessage();
-            isNoData = false;
-        }
+    private void setUsingPeriodMessage(int period) {
+        mainView.changeUsePeriodMessage(period);
     }
 
     @Override
@@ -85,7 +79,7 @@ public class MainPresenter implements MainContract.Presenter {
     public void changeMask(Context context) {
 
         if (!WaskApplication.isChanged) {
-            checkIsFirstReplacement();
+//            checkIsFirstReplacement(getMaskPeriod());
 
             replacementHistoryRepository.insertToday(new ReplacementHistoryRepository.InsertHistoryCallback() {
                 @Override
@@ -166,7 +160,6 @@ public class MainPresenter implements MainContract.Presenter {
         int lastReplacement = replacementHistoryRepository.getLastReplacement();
         if (lastReplacement == -1) {
             //교체 기록이 없을 경우
-            isNoData = true;
             return 0;
         }
         return DateUtils.calculateDateGapWithToday(lastReplacement) + 1;

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -107,7 +107,7 @@
                 android:textStyle="bold" />
 
             <com.naccoro.wask.customview.PeriodPresenter
-                android:id="@+id/textview_use_period_message"
+                android:id="@+id/periodpresenter_use_period_message"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/period_suffix_current_using"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -106,13 +106,14 @@
                 android:textSize="@dimen/textsize_mainuseperiod_number"
                 android:textStyle="bold" />
 
-            <TextView
+            <com.naccoro.wask.customview.PeriodPresenter
                 android:id="@+id/textview_use_period_message"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/main_use_period_message"
+                android:text="@string/period_suffix_current_using"
                 android:textColor="@color/waskGrayFont"
-                android:textSize="@dimen/textsize_mainuseperiod_text"/>
+                android:textSize="@dimen/textsize_mainuseperiod_text"
+                app:type="current_using"/>
         </LinearLayout>
 
         <TextView

--- a/app/src/main/res/layout/activity_setting.xml
+++ b/app/src/main/res/layout/activity_setting.xml
@@ -46,8 +46,8 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <TextView
-                android:id="@+id/textview_replacementcyclealert_body"
+            <com.naccoro.wask.customview.PeriodPresenter
+                android:id="@+id/periodpresenter_replacementcyclealert_body"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/margin_settingchild_bottom"
@@ -55,6 +55,7 @@
                 android:lineSpacingExtra="6sp"
                 android:textColor="@color/waskAccentFont"
                 android:textSize="@dimen/textsize_setting_body"
+                app:type="replacement_cycle"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="@+id/textview_replacementcyclealert_title"
                 app:layout_constraintTop_toBottomOf="@+id/textview_replacementcyclealert_title"
@@ -85,8 +86,8 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <TextView
-                android:id="@+id/textview_replacelater_body"
+            <com.naccoro.wask.customview.PeriodPresenter
+                android:id="@+id/periodpresenter_replacelater_body"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/margin_settingchild_bottom"
@@ -94,6 +95,7 @@
                 android:lineSpacingExtra="6sp"
                 android:textColor="@color/waskAccentFont"
                 android:textSize="@dimen/textsize_setting_body"
+                app:type="snooze_reminder"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="@+id/textview_replacelater_title"
                 app:layout_constraintTop_toBottomOf="@+id/textview_replacelater_title"

--- a/app/src/main/res/layout/dialog_replacelater.xml
+++ b/app/src/main/res/layout/dialog_replacelater.xml
@@ -5,6 +5,16 @@
     android:layout_height="wrap_content"
     android:layout_gravity="center">
 
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/period_prefix_snooze"
+        android:textColor="@color/waskGrayFont"
+        android:textSize="@dimen/textsize_dialogreplacementcycle_body"
+        app:layout_constraintEnd_toStartOf="@id/wheelrecycler_replacelater"
+        app:layout_constraintTop_toTopOf="@id/wheelrecycler_replacelater"
+        app:layout_constraintBottom_toBottomOf="@id/wheelrecycler_replacelater"/>
+
     <com.naccoro.wask.customview.datepicker.wheel.WheelRecyclerView
         android:id="@+id/wheelrecycler_replacelater"
         android:layout_width="0dp"
@@ -21,7 +31,7 @@
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/dialog_replacelater"
+        android:text="@string/period_suffix_snooze"
         android:textColor="@color/waskGrayFont"
         android:textSize="@dimen/textsize_dialogreplacementcycle_body"
         app:layout_constraintBottom_toBottomOf="@+id/wheelrecycler_replacelater"

--- a/app/src/main/res/layout/dialog_replacementcycle.xml
+++ b/app/src/main/res/layout/dialog_replacementcycle.xml
@@ -4,6 +4,16 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/period_prefix_cycle"
+        android:textColor="@color/waskGrayFont"
+        android:textSize="@dimen/textsize_dialogreplacementcycle_body"
+        app:layout_constraintEnd_toStartOf="@id/wheelrecycler_replacementcycle"
+        app:layout_constraintTop_toTopOf="@id/wheelrecycler_replacementcycle"
+        app:layout_constraintBottom_toBottomOf="@id/wheelrecycler_replacementcycle"/>
+
     <com.naccoro.wask.customview.datepicker.wheel.WheelRecyclerView
         android:id="@+id/wheelrecycler_replacementcycle"
         android:layout_width="0dp"
@@ -20,7 +30,7 @@
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/dialog_replacementcycle"
+        android:text="@string/period_suffix_cycle"
         android:textColor="@color/waskGrayFont"
         android:textSize="@dimen/textsize_dialogreplacementcycle_body"
         app:layout_constraintBottom_toBottomOf="@+id/wheelrecycler_replacementcycle"

--- a/app/src/main/res/values-en-rUS/strings.xml
+++ b/app/src/main/res/values-en-rUS/strings.xml
@@ -15,7 +15,7 @@
 
     <string name="main_card_good">Use one mask a day</string>
     <string name="main_card_bad">Time to change your mask!</string>
-    <string name="main_use_period_message">days used</string>
+    <string name="period_suffix_current_using">days used</string>
     <string name="main_use_period_message_no_replacement">No data</string>
     <string name="main_change_button">Change</string>
     <string name="main_cancel_replacement">Cancel</string>
@@ -61,5 +61,13 @@
     <string name="wheel_day"></string>
 
     <string name="notification_alert">You\'ve been wearing your mask for %d days</string>
+
+    <string name="period_prefix_snooze">in&#160;</string>
+    <string name="period_prefix_cycle">Every&#160;</string>
+    <string name="period_suffix_singular">&#160;day</string>
+    <string name="period_suffix_plural">&#160;days</string>
+    <string name="period_suffix_used">&#160;used</string>
+    <string name="period_suffix_cycle">@string/period_suffix_plural</string>
+    <string name="period_suffix_snooze">@string/period_suffix_plural</string>
 
 </resources>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -15,7 +15,7 @@
 
     <string name="main_card_good">마스크 1일 1사용을 권장합니다</string>
     <string name="main_card_bad">마스크를 교체하는 것을 권장합니다</string>
-    <string name="main_use_period_message">일 째 사용중</string>
+    <string name="period_suffix_current_using">일 째 사용중</string>
     <string name="main_use_period_message_no_replacement">교체 기록이 없습니다.</string>
     <string name="main_change_button">교체하기</string>
     <string name="main_cancel_replacement">교체 취소</string>
@@ -60,5 +60,13 @@
     <string name="wheel_day">일</string>
 
     <string name="notification_alert">마스크를 %d일 째 사용중입니다</string>
+
+    <string name="period_prefix_snooze"></string>
+    <string name="period_prefix_cycle"></string>
+    <string name="period_suffix_singular"></string>
+    <string name="period_suffix_plural"></string>
+    <string name="period_suffix_used"></string>
+    <string name="period_suffix_cycle">일 마다</string>
+    <string name="period_suffix_snooze">일 뒤</string>
 
 </resources>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="PeriodPresenter">
+        <attr name="type" format="enum">
+            <enum name="replacement_cycle" value="0"/>
+            <enum name="snooze_reminder" value="1"/>
+            <enum name="current_using" value="2"/>
+        </attr>
+    </declare-styleable>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,18 +4,18 @@
     <string name="setting_title">설정</string>
     <string name="setting_replacement_cycle">마스크 교체 알림 주기</string>
     <string name="setting_replace_later">나중에 교체하기</string>
-    <string name="setting_push_alert">푸시알람</string>
+    <string name="setting_push_alert">푸시알림</string>
     <string name="setting_foreground_alert">마스크 사용 일자 알림바 보이기</string>
     <string name="setting_dialog_ok">확인</string>
     <string name="setting_push_alert_sound">소리</string>
     <string name="setting_push_alert_vibration">진동</string>
     <string name="setting_push_alert_all">소리+진동</string>
-    <string name="setting_push_alert_none">없음</string>
-    <string name="setting_day">일</string>
+    <string name="setting_push_alert_none">무음</string>
+    <string name="setting_day">%d일</string>
 
     <string name="main_card_good">마스크 1일 1사용을 권장합니다</string>
     <string name="main_card_bad">마스크를 교체하는 것을 권장합니다</string>
-    <string name="main_use_period_message">일 째 사용중</string>
+    <string name="period_suffix_current_using">일 째 사용중</string>
     <string name="main_use_period_message_no_replacement">교체 기록이 없습니다</string>
     <string name="main_change_button">교체하기</string>
     <string name="main_cancel_replacement">교체 취소</string>
@@ -61,5 +61,13 @@
     <string name="wheel_day">일</string>
 
     <string name="notification_alert">마스크를 %d일 째 사용중입니다</string>
+
+    <string name="period_prefix_snooze"></string>
+    <string name="period_prefix_cycle"></string>
+    <string name="period_suffix_singular"></string>
+    <string name="period_suffix_plural"></string>
+    <string name="period_suffix_used"></string>
+    <string name="period_suffix_cycle">일 마다</string>
+    <string name="period_suffix_snooze">일 뒤</string>
 
 </resources>


### PR DESCRIPTION
`PeriodPresenter` 커스텀뷰를 만들어 day/days, Every/in, 그리고 한국어/영어 일 경우에 대한 주기 표기법을 책임지도록 하였습니다.

위와 같이 표기법을 분기시키는 조건이 생각보다 많기 때문에 Activity, presenter 컴포넌트에서 이를 실행하기에는 코드가 복잡해지고 유지보수가 어려울 것이라 예상하여 해당 로직을 모두 커스텀뷰에 몰아넣었습니다.

문자열 조합에 대한 센스가 조금 부족하여 약간 코드가 이쁘진 않습니다.

## 구조
주기를 나타내는 문자열은 아래와 같은 구성으로 나타납니다.
`prefix("" | "Every" | "in")` + `period(int | null)` + `suffix("day" | "days" | "일 마다" | "일 뒤" | "일 째 사용중")` + `extra("" | "used")`
각 조건에 따라 위 구성을 달리해주었고 extra 는 suffix 내에서 함께 연산해주었습니다.

## 속성
```
<com.naccoro.wask.customview.PeriodPresenter
    app:type="replacement_cycle" | "snooze_reminder" | "current_using"
    ...
/>
```
위 type 속성을 추가하여 xml 상에서 교체 주기, 나중에 교체하기, 사용 일자 세가지 경우에 대해 분기할 수 있도록 하였습니다.

## 추가적인 수정
1. 다이얼로그에서도 위와 같은 구조가 나타나도록 하였습니다. 이 부분은 그냥 strings.xml로 대처가 간단히 되었습니다.
2. 알림 방식 (소리, 진동 등) 에서 "없음" 이라는 선택지가 알림이 없다는 뜻으로 받아들여질 것 같아 "무음" 으로 수정하였습니다.
3. 메인화면에서 첫 번째 교체가 아닌 이상 "일 째 사용중" 이라는 문구가 변동이 없어서 첫 번째 교체인지 아닌지를 판단하는 메서드가 있었습니다.
    - 그러나 이제 day/days 와 같은 단수 복수를 고려하기도 해야해서 첫 번째 교체인지 아닌지에 대한 조건은 삭제하여 매번 period를 검사해 문구를 적절하게 변경하도록 하였습니다.

# 결과
## 영어
### 설정창
<p>
<img width="300" alt="스크린샷 2020-12-06 오전 11 45 33" src="https://user-images.githubusercontent.com/57310034/101270320-31de5b00-37bb-11eb-995a-e64b6e55543e.png">
<img width="300" alt="스크린샷 2020-12-06 오전 11 48 19" src="https://user-images.githubusercontent.com/57310034/101270334-491d4880-37bb-11eb-9121-758989151f0e.png">
</p>

### 다이얼로그
<p>
<img width="300" alt="스크린샷 2020-12-06 오전 11 45 13" src="https://user-images.githubusercontent.com/57310034/101270350-6e11bb80-37bb-11eb-8d9c-edeaaf4c15ab.png">
<img width="300" alt="스크린샷 2020-12-06 오전 11 45 22" src="https://user-images.githubusercontent.com/57310034/101270354-72d66f80-37bb-11eb-83be-fcac5204a978.png">
</p>

### 메인화면
<p>
<img width="300" alt="스크린샷 2020-12-06 오전 11 45 50" src="https://user-images.githubusercontent.com/57310034/101270363-94cff200-37bb-11eb-8425-c43980f00ba3.png">
<img width="300" alt="스크린샷 2020-12-06 오전 11 46 08" src="https://user-images.githubusercontent.com/57310034/101270372-bf21af80-37bb-11eb-8a63-5b952137592d.png">
</p>

## 한국어

### 설정창
<img width="300" alt="스크린샷 2020-12-06 오전 11 47 29" src="https://user-images.githubusercontent.com/57310034/101270382-dbbde780-37bb-11eb-9b83-7161093248d6.png">
** 버그 발생 **

### 다이얼로그
<p>
<img width="300" alt="스크린샷 2020-12-06 오전 11 47 10" src="https://user-images.githubusercontent.com/57310034/101270389-ed06f400-37bb-11eb-93e0-b8c326b48eb7.png">
<img width="300" alt="스크린샷 2020-12-06 오전 11 47 20" src="https://user-images.githubusercontent.com/57310034/101270391-eed0b780-37bb-11eb-9559-0e486bc0bcf9.png">
</p>


#### 추가로 이 과정에서 버그를 발견하였는데, 알림 소리에 대한 설정값이 `String` 형태로 `SharedPreference`에 저장되어, 만약 영어 버전에서 해당 값을 바꿨다면, 한국어 버전에서는 영어로 된 설정값이 보여집니다. 이 현상은 역으로도 발생할 것이며, `SharedPreference`에 설정 값에 대한 `index`를 저장하고, `string array`를 사용하여 최종 문자열을 선정하는 방식으로 변경해야할 것 같습니다.



