### PR TITLE
refactor: 푸시알림방식을 StringArray를 통해 표현할 수 있도록 수정

### DIFF
--- a/app/src/main/java/com/naccoro/wask/preferences/SettingPreferenceManager.java
+++ b/app/src/main/java/com/naccoro/wask/preferences/SettingPreferenceManager.java
@@ -56,22 +56,16 @@ public class SettingPreferenceManager {
      * SOUND : 소리, VIBRATION : 진동, ALL : 소리+진동, NONE : 없음
      */
     public enum SettingPushAlertType {
-        SOUND(0, "소리"), VIBRATION(1, "진동"), ALL(2, "소리+진동"), NONE(3, "없음");
+        SOUND(0), VIBRATION(1), ALL(2), NONE(3);
 
-        private int typeIndex;
-        private String typeValue;
+        private final int typeIndex;
 
-        SettingPushAlertType(int index, String value) {
+        SettingPushAlertType(int index) {
             this.typeIndex = index;
-            this.typeValue = value;
         }
 
         public int getTypeIndex() {
             return typeIndex;
-        }
-
-        public String getTypeValue() {
-            return typeValue;
         }
 
         /**
@@ -89,28 +83,6 @@ public class SettingPreferenceManager {
                     return SettingPreferenceManager.SettingPushAlertType.VIBRATION;
 
                 case 2:
-                    return SettingPreferenceManager.SettingPushAlertType.ALL;
-
-                default:
-                    return SettingPreferenceManager.SettingPushAlertType.NONE;
-            }
-        }
-
-        /**
-         * enum class인 SettngPushAlertType을 value 매개변수로 구하는 함수
-         *
-         * @param value : 구하고자 하는 value
-         * @return : 구한 SettingPushAlertType 객체
-         */
-        public static SettingPreferenceManager.SettingPushAlertType getPushAlertTypeWithValue(String value) {
-            switch (value) {
-                case "소리":
-                    return SettingPreferenceManager.SettingPushAlertType.SOUND;
-
-                case "진동":
-                    return SettingPreferenceManager.SettingPushAlertType.VIBRATION;
-
-                case "소리+진동":
                     return SettingPreferenceManager.SettingPushAlertType.ALL;
 
                 default:

--- a/app/src/main/java/com/naccoro/wask/setting/SettingActivity.java
+++ b/app/src/main/java/com/naccoro/wask/setting/SettingActivity.java
@@ -11,6 +11,8 @@ import com.naccoro.wask.customview.datepicker.wheel.WheelRecyclerView;
 import com.naccoro.wask.customview.waskdialog.WaskDialog;
 import com.naccoro.wask.customview.waskdialog.WaskDialogBuilder;
 import com.naccoro.wask.notification.ServiceUtil;
+import com.naccoro.wask.preferences.SettingPreferenceManager;
+import com.naccoro.wask.preferences.SharedPreferenceManager;
 import com.naccoro.wask.utils.AlarmUtil;
 
 public class SettingActivity extends AppCompatActivity
@@ -43,7 +45,7 @@ public class SettingActivity extends AppCompatActivity
         init();
 
         //start()함수를 호출하여 초기 설정값을 불러옴
-        presenter.start();
+        presenter.start(this);
 
         //영구 알림 스위치 리스너 초기화
         initSwitchListener();
@@ -122,19 +124,19 @@ public class SettingActivity extends AppCompatActivity
         new WaskDialogBuilder()
                 .setTitle(getString(R.string.setting_push_alert))
                 .addVerticalButton(getString(R.string.setting_push_alert_sound), (dialog, view) -> {
-                    presenter.changePushAlertValue(this, getString(R.string.setting_push_alert_sound));
+                    presenter.changePushAlertValue(this, SettingPreferenceManager.SettingPushAlertType.SOUND);
                     dialog.dismiss();
                 })
                 .addVerticalButton(getString(R.string.setting_push_alert_vibration), (dialog, view) -> {
-                    presenter.changePushAlertValue(this, getString(R.string.setting_push_alert_vibration));
+                    presenter.changePushAlertValue(this, SettingPreferenceManager.SettingPushAlertType.VIBRATION);
                     dialog.dismiss();
                 })
                 .addVerticalButton(getString(R.string.setting_push_alert_all), (dialog, view) -> {
-                    presenter.changePushAlertValue(this, getString(R.string.setting_push_alert_all));
+                    presenter.changePushAlertValue(this, SettingPreferenceManager.SettingPushAlertType.ALL);
                     dialog.dismiss();
                 })
                 .addVerticalButton(getString(R.string.setting_push_alert_none), (dialog, view) -> {
-                    presenter.changePushAlertValue(this, getString(R.string.setting_push_alert_none));
+                    presenter.changePushAlertValue(this, SettingPreferenceManager.SettingPushAlertType.NONE);
                     dialog.dismiss();
                 })
                 .build()

--- a/app/src/main/java/com/naccoro/wask/setting/SettingContract.java
+++ b/app/src/main/java/com/naccoro/wask/setting/SettingContract.java
@@ -2,6 +2,8 @@ package com.naccoro.wask.setting;
 
 import android.content.Context;
 
+import com.naccoro.wask.preferences.SettingPreferenceManager;
+
 public interface SettingContract {
     interface View {
         void showReplacementCycleDialog();
@@ -26,7 +28,7 @@ public interface SettingContract {
     }
 
     interface Presenter {
-        void start();
+        void start(Context context);
 
         void clickHomeButton();
 
@@ -38,7 +40,7 @@ public interface SettingContract {
 
         void changeAlertVisibleSwitch(Context context, boolean isChecked);
 
-        void changePushAlertValue(Context context, String value);
+        void changePushAlertValue(Context context, SettingPreferenceManager.SettingPushAlertType value);
 
         void changeReplacementCycleValue(Context context, int cycleValue);
 

--- a/app/src/main/java/com/naccoro/wask/setting/SettingPresenter.java
+++ b/app/src/main/java/com/naccoro/wask/setting/SettingPresenter.java
@@ -2,6 +2,7 @@ package com.naccoro.wask.setting;
 
 import android.content.Context;
 
+import com.naccoro.wask.R;
 import com.naccoro.wask.mock.MockDatabase;
 import com.naccoro.wask.preferences.SettingPreferenceManager;
 import com.naccoro.wask.replacement.model.Injection;
@@ -11,7 +12,6 @@ import com.naccoro.wask.utils.DateUtils;
 import com.naccoro.wask.utils.NotificationUtil;
 
 import static com.naccoro.wask.preferences.SettingPreferenceManager.SettingPushAlertType.getPushAlertTypeWithIndex;
-import static com.naccoro.wask.preferences.SettingPreferenceManager.SettingPushAlertType.getPushAlertTypeWithValue;
 
 public class SettingPresenter implements SettingContract.Presenter {
 
@@ -22,7 +22,7 @@ public class SettingPresenter implements SettingContract.Presenter {
     }
 
     @Override
-    public void start() {
+    public void start(Context context) {
         int replaceCycleValue = SettingPreferenceManager.getReplaceCycle();
         settingView.showReplacementCycleValue(replaceCycleValue);
 
@@ -30,8 +30,7 @@ public class SettingPresenter implements SettingContract.Presenter {
         settingView.showReplaceLaterValue(replaceLaterValue);
 
         int pushAlertIndex = SettingPreferenceManager.getPushAlert();
-        SettingPreferenceManager.SettingPushAlertType pushAlertType = getPushAlertTypeWithIndex(pushAlertIndex);
-        settingView.showPushAlertValue(pushAlertType.getTypeValue());
+        settingView.showPushAlertValue(getPushAlertTypeString(context, pushAlertIndex));
 
         boolean isShowNotificationBar = SettingPreferenceManager.getIsShowNotificationBar();
         settingView.setAlertVisibleSwitchValue(isShowNotificationBar);
@@ -84,11 +83,11 @@ public class SettingPresenter implements SettingContract.Presenter {
      * @param value: 사용자가 설정한 값  e.g 소리, 진동, 소리+진동, 없음
      */
     @Override
-    public void changePushAlertValue(Context context, String value) {
+    public void changePushAlertValue(Context context, SettingPreferenceManager.SettingPushAlertType value) {
         int oldValue = SettingPreferenceManager.getPushAlert();
+        int newValue = value.getTypeIndex();
 
-        SettingPreferenceManager.SettingPushAlertType pushAlertType = getPushAlertTypeWithValue(value);
-        SettingPreferenceManager.setPushAlert(pushAlertType.getTypeIndex());
+        SettingPreferenceManager.setPushAlert(newValue);
 
         MockDatabase.MockNotificationData pushAlertData = MockDatabase.getReplacementCycleData(context);
 
@@ -97,7 +96,8 @@ public class SettingPresenter implements SettingContract.Presenter {
         //새롭게 변경된 설정 적용하여 channel 생성
         NotificationUtil.createNotificationChannel(context, pushAlertData);
 
-        settingView.showPushAlertValue(value);
+        //설정 값에 대응하는 문자열을 보여주기
+        settingView.showPushAlertValue(getPushAlertTypeString(context,newValue));
     }
 
     /**
@@ -145,5 +145,10 @@ public class SettingPresenter implements SettingContract.Presenter {
             return 0;
         }
         return DateUtils.calculateDateGapWithToday(lastReplacement) + 1;
+    }
+
+    //StringArray에서 인덱스에 해당하는 푸시 알림 방식 문자열을 불러오기
+    private String getPushAlertTypeString(Context context, int index) {
+        return context.getResources().getStringArray(R.array.ALERT_TYPE)[index];
     }
 }

--- a/app/src/main/res/values/alert_type_strings.xml
+++ b/app/src/main/res/values/alert_type_strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="ALERT_TYPE">
+        <item>@string/setting_push_alert_sound</item>
+        <item>@string/setting_push_alert_vibration</item>
+        <item>@string/setting_push_alert_all</item>
+        <item>@string/setting_push_alert_none</item>
+    </string-array>
+</resources>


### PR DESCRIPTION
# 개요
다국어 지원 과정에서 해당 부분만 이전에 설정되어 있던 언어의 형태로 세팅값이 보여지는 문제점을 확인하였습니다.
`SharedPreference`에 문자열을 그대로 저장해서 생긴 문제라고 생각하였으나, 코드를 보니`int`값을 저장하고 있었습니다.

# 문제점
문제는 이 `int`값과 `String` 값을 매칭하고 관리하는 `Enum` 클래스에 있었습니다.
각 인덱스에 대칭하는 문자열을 불러오는 함수에서 한글로 된 문자열을 하드코딩하고 있음을 발견하였습니다.

# 해결방법
해당 부분만 `strings.xml`을 참고하도록 수정해도 되지만, `switch` 문 보다 `StringArray`가 조금 더 코드가 깔끔할 것 같아 `StringArray`를 사용하여 참조할 수 있도록 하였습니다.

# 고민
`StringArray`에 접근하는 로직은 `SettingPresenter`에 위치시켰습니다. 이를 모두 `Enum` 클래스 안에 두고 한 곳에서 관리할까 생각해보았지만, `Resource`에 접근하기 위한 `Context`를 최대한 가까이서 관리하는 것이 좋을 것 같다는 생각을 하였습니다. (정확한 근거는 들지 못하지만 `Context`를 매개변수로 넘기는 행위를 무분별하게 하면 안될 것 같은 본능적인 느낌..) 아니면 `WaskApplication`에서 `Application Context`를 받아와 `Enum` 클래스 안에서 가져와도 됩니다. 어떤 방식이 더 좋을지 의견 궁금합니다 !
