### PR TITLE
fix: 앱 내에서 선택한 언어와 무관하게, 디바이스 설정에 따라 캘린더 "월" 이름이 보여지던 문제 해결

### DIFF
--- a/app/src/main/java/com/naccoro/wask/customview/DatePresenter.java
+++ b/app/src/main/java/com/naccoro/wask/customview/DatePresenter.java
@@ -36,9 +36,7 @@ public class DatePresenter extends LinearLayout {
     private TextView monthText;
     private ImageView arrowImage;
     private Date date;
-
-    private DateFormatSymbols dateFormatSymbols;
-
+    
     public DatePresenter(Context context) {
         super(context);
         init();
@@ -163,10 +161,7 @@ public class DatePresenter extends LinearLayout {
 
     //영어인 경우, 월의 이름(November, December 등) 가져오기
     private String getMonthName(int month) {
-        if (dateFormatSymbols == null) {
-            dateFormatSymbols = new DateFormatSymbols();
-        }
-        return dateFormatSymbols.getMonths()[month];
+        return getResources().getStringArray(R.array.date_full_month_name)[month];
     }
 
     /**

--- a/app/src/main/res/values-en-rUS/strings.xml
+++ b/app/src/main/res/values-en-rUS/strings.xml
@@ -71,6 +71,21 @@
         <item>Dec</item>
     </string-array>
 
+    <string-array name="date_full_month_name">
+        <item>January</item>
+        <item>February</item>
+        <item>March</item>
+        <item>April</item>
+        <item>May</item>
+        <item>June</item>
+        <item>July</item>
+        <item>August</item>
+        <item>September</item>
+        <item>October</item>
+        <item>November</item>
+        <item>December</item>
+    </string-array>
+
     <string name="wheel_year"></string>
     <string name="wheel_month"></string>
     <string name="wheel_day"></string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -70,6 +70,21 @@
         <item>12</item>
     </string-array>
 
+    <string-array name="date_full_month_name">
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+        <item>6</item>
+        <item>7</item>
+        <item>8</item>
+        <item>9</item>
+        <item>10</item>
+        <item>11</item>
+        <item>12</item>
+    </string-array>
+
     <string name="wheel_year">년</string>
     <string name="wheel_month">월</string>
     <string name="wheel_day">일</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,6 +71,21 @@
         <item>12</item>
     </string-array>
 
+    <string-array name="date_full_month_name">
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+        <item>6</item>
+        <item>7</item>
+        <item>8</item>
+        <item>9</item>
+        <item>10</item>
+        <item>11</item>
+        <item>12</item>
+    </string-array>
+
     <string name="wheel_year">년</string>
     <string name="wheel_month">월</string>
     <string name="wheel_day">일</string>


### PR DESCRIPTION
영어로 설정된 경우, 기존에는 `DateFormatSymbols` 클래스를 사용하여 캘린더의 "월" 이름을 가져와 보여주었습니다.
하지만 이 클래스의 경우 디바이스 설정을 맹목적으로 따라감을 발견하였습니다.
즉, 앱 내에서 영어로 변경하여도 디바이스 설정이 한국어이면 한국어로 "월" 이름을 반환합니다.
따라서 이 부분을 제거하고 `StringArray` 형태로 변경하였습니다. (민욱님의 빅픽쳐.. 저는 멀었습니다.)
