### PR TITLE
Presenter에서 안드로이드 프레임워크 종속성 해제

### DIFF
--- a/app/src/main/java/com/naccoro/wask/setting/SettingActivity.java
+++ b/app/src/main/java/com/naccoro/wask/setting/SettingActivity.java
@@ -48,7 +48,7 @@ public class SettingActivity extends AppCompatActivity
         init();
 
         //start()함수를 호출하여 초기 설정값을 불러옴
-        presenter.start(this);
+        presenter.start();
 
         //영구 알림 스위치 리스너 초기화
         initSwitchListener();
@@ -76,7 +76,7 @@ public class SettingActivity extends AppCompatActivity
 
     private void initSwitchListener() {
         alertVisibleSwitch.setOnCheckedChangeListener((compoundButton, isChecked) ->
-                presenter.changeAlertVisibleSwitch(SettingActivity.this, isChecked));
+                presenter.changeAlertVisibleSwitch(isChecked));
     }
 
     @Override
@@ -94,7 +94,7 @@ public class SettingActivity extends AppCompatActivity
                 .addHorizontalButton(getString(R.string.setting_dialog_ok), (dialog, view) -> {
                     //이후 wheelPicker value로 대체
                     WheelRecyclerView wheelRecyclerView = view.findViewById(R.id.wheelrecycler_replacementcycle);
-                    presenter.changeReplacementCycleValue(SettingActivity.this, wheelRecyclerView.getWheelValue());
+                    presenter.changeReplacementCycleValue(wheelRecyclerView.getWheelValue());
                     dialog.dismiss();
                 })
                 .build()
@@ -117,7 +117,7 @@ public class SettingActivity extends AppCompatActivity
                 .addHorizontalButton(getString(R.string.setting_dialog_ok), (dialog, view) -> {
                     //이후 wheelPicker value로 대체
                     WheelRecyclerView wheelRecyclerView = view.findViewById(R.id.wheelrecycler_replacelater);
-                    presenter.changeReplaceLaterValue(SettingActivity.this, wheelRecyclerView.getWheelValue());
+                    presenter.changeReplaceLaterValue(wheelRecyclerView.getWheelValue());
                     dialog.dismiss();
                 })
                 .build()
@@ -129,19 +129,19 @@ public class SettingActivity extends AppCompatActivity
         new WaskDialogBuilder()
                 .setTitle(getString(R.string.setting_push_alert))
                 .addVerticalButton(getString(R.string.setting_push_alert_sound), (dialog, view) -> {
-                    presenter.changePushAlertValue(this, SettingPreferenceManager.SettingPushAlertType.SOUND);
+                    presenter.changePushAlertValue(SettingPreferenceManager.SettingPushAlertType.SOUND);
                     dialog.dismiss();
                 })
                 .addVerticalButton(getString(R.string.setting_push_alert_vibration), (dialog, view) -> {
-                    presenter.changePushAlertValue(this, SettingPreferenceManager.SettingPushAlertType.VIBRATION);
+                    presenter.changePushAlertValue(SettingPreferenceManager.SettingPushAlertType.VIBRATION);
                     dialog.dismiss();
                 })
                 .addVerticalButton(getString(R.string.setting_push_alert_all), (dialog, view) -> {
-                    presenter.changePushAlertValue(this, SettingPreferenceManager.SettingPushAlertType.ALL);
+                    presenter.changePushAlertValue(SettingPreferenceManager.SettingPushAlertType.ALL);
                     dialog.dismiss();
                 })
                 .addVerticalButton(getString(R.string.setting_push_alert_none), (dialog, view) -> {
-                    presenter.changePushAlertValue(this, SettingPreferenceManager.SettingPushAlertType.NONE);
+                    presenter.changePushAlertValue(SettingPreferenceManager.SettingPushAlertType.NONE);
                     dialog.dismiss();
                 })
                 .build()

--- a/app/src/main/java/com/naccoro/wask/setting/SettingActivity.java
+++ b/app/src/main/java/com/naccoro/wask/setting/SettingActivity.java
@@ -18,6 +18,7 @@ import com.naccoro.wask.notification.ServiceUtil;
 import com.naccoro.wask.preferences.SettingPreferenceManager;
 import com.naccoro.wask.replacement.model.Injection;
 import com.naccoro.wask.utils.AlarmUtil;
+import com.naccoro.wask.utils.LanguageUtil;
 import com.naccoro.wask.utils.NotificationUtil;
 
 public class SettingActivity extends AppCompatActivity
@@ -276,6 +277,11 @@ public class SettingActivity extends AppCompatActivity
     @Override
     public String getPushAlertTypeString(int index) {
         return getResources().getStringArray(R.array.ALERT_TYPE)[index];
+    }
+
+    @Override
+    public String getLanguageString(int languageIndex) {
+        return LanguageUtil.getLanguageString(this, languageIndex);
     }
 
     @Override

--- a/app/src/main/java/com/naccoro/wask/setting/SettingContract.java
+++ b/app/src/main/java/com/naccoro/wask/setting/SettingContract.java
@@ -39,6 +39,8 @@ public interface SettingContract {
         void refreshAlarmInSnooze();
 
         String getPushAlertTypeString(int index);
+
+        String getLanguageString(int languageIndex);
     }
 
     interface Presenter {
@@ -52,8 +54,6 @@ public interface SettingContract {
 
         void clickPushAlert();
 
-        void changeAlertVisibleSwitch(boolean isChecked);
-
         void clickLanguage();
 
         void changeAlertVisibleSwitch(boolean isChecked);
@@ -61,8 +61,6 @@ public interface SettingContract {
         void changePushAlertValue(SettingPreferenceManager.SettingPushAlertType value);
 
         void changeReplacementCycleValue(int cycleValue);
-
-        void changeReplaceLaterValue(int laterValue);
 
         void changeReplaceLaterValue(int laterValue);
 

--- a/app/src/main/java/com/naccoro/wask/setting/SettingContract.java
+++ b/app/src/main/java/com/naccoro/wask/setting/SettingContract.java
@@ -1,7 +1,5 @@
 package com.naccoro.wask.setting;
 
-import android.content.Context;
-
 import com.naccoro.wask.preferences.SettingPreferenceManager;
 
 public interface SettingContract {
@@ -27,6 +25,14 @@ public interface SettingContract {
         void finishSettingView();
 
         void showSnoozeInfoDialog();
+
+        void updateNotificationChanel(SettingPreferenceManager.SettingPushAlertType pushAlertTypeWithIndex);
+
+        void refreshAlarm();
+
+        void refreshAlarmInSnooze();
+
+        String getPushAlertTypeString(int index);
     }
 
     interface Presenter {

--- a/app/src/main/java/com/naccoro/wask/setting/SettingContract.java
+++ b/app/src/main/java/com/naccoro/wask/setting/SettingContract.java
@@ -30,7 +30,7 @@ public interface SettingContract {
     }
 
     interface Presenter {
-        void start(Context context);
+        void start();
 
         void clickHomeButton();
 
@@ -40,12 +40,12 @@ public interface SettingContract {
 
         void clickPushAlert();
 
-        void changeAlertVisibleSwitch(Context context, boolean isChecked);
+        void changeAlertVisibleSwitch(boolean isChecked);
 
-        void changePushAlertValue(Context context, SettingPreferenceManager.SettingPushAlertType value);
+        void changePushAlertValue(SettingPreferenceManager.SettingPushAlertType value);
 
-        void changeReplacementCycleValue(Context context, int cycleValue);
+        void changeReplacementCycleValue(int cycleValue);
 
-        void changeReplaceLaterValue(Context context, int laterValue);
+        void changeReplaceLaterValue(int laterValue);
     }
 }

--- a/app/src/main/java/com/naccoro/wask/setting/SettingPresenter.java
+++ b/app/src/main/java/com/naccoro/wask/setting/SettingPresenter.java
@@ -3,7 +3,6 @@ package com.naccoro.wask.setting;
 import com.naccoro.wask.preferences.SettingPreferenceManager;
 import com.naccoro.wask.replacement.repository.ReplacementHistoryRepository;
 import com.naccoro.wask.utils.DateUtils;
-import com.naccoro.wask.utils.LanguageUtil;
 
 import static com.naccoro.wask.preferences.SettingPreferenceManager.SettingPushAlertType.getPushAlertTypeWithIndex;
 
@@ -29,7 +28,7 @@ public class SettingPresenter implements SettingContract.Presenter {
         settingView.showPushAlertValue(getPushAlertTypeString(pushAlertIndex));
 
         int languageIndex = SettingPreferenceManager.getLanguage();
-        settingView.showLanguageLabel(LanguageUtil.getLanguageString(languageIndex));
+        settingView.showLanguageLabel(settingView.getLanguageString(languageIndex));
 
         boolean isShowNotificationBar = SettingPreferenceManager.getIsShowNotificationBar();
         settingView.setAlertVisibleSwitchValue(isShowNotificationBar);

--- a/app/src/main/java/com/naccoro/wask/ui/main/MainActivity.java
+++ b/app/src/main/java/com/naccoro/wask/ui/main/MainActivity.java
@@ -11,11 +11,13 @@ import android.widget.Toast;
 
 import com.naccoro.wask.R;
 import com.naccoro.wask.customview.PeriodPresenter;
+import com.naccoro.wask.notification.ServiceUtil;
 import com.naccoro.wask.ui.calendar.CalendarActivity;
 import com.naccoro.wask.customview.WaskToolbar;
 import com.naccoro.wask.customview.waskdialog.WaskDialogBuilder;
 import com.naccoro.wask.replacement.model.Injection;
 import com.naccoro.wask.setting.SettingActivity;
+import com.naccoro.wask.utils.AlarmUtil;
 
 public class MainActivity extends AppCompatActivity
         implements View.OnClickListener, MainContract.View {
@@ -160,5 +162,31 @@ public class MainActivity extends AppCompatActivity
     public void changeUsePeriodMessage(int period) {
         usePeriodTextView.setVisibility(View.VISIBLE);
         usePeriodMessageTextView.setPeriod(period);
+    }
+
+    @Override
+    public void setMaskReplaceNotification() {
+        //기본 교체하기 알람이 있었다면 제거
+        if (AlarmUtil.isCycleAlarmExist(this)) {
+            AlarmUtil.cancelReplacementCycleAlarm(this);
+
+            //나중에 교체하기 알림 중이었다면 제거
+        } else if (AlarmUtil.isLaterAlarmExist(this)) {
+            AlarmUtil.cancelReplaceLaterAlarm(this);
+        }
+
+        presenter.showForegroundNotification();
+        AlarmUtil.setReplacementCycleAlarm(this);
+    }
+
+    @Override
+    public void showForegroundNotification(int period) {
+        if (period > 0) {
+            ServiceUtil.showForegroundService(this, period);
+            AlarmUtil.setForegroundAlarm(this);
+        } else {
+            ServiceUtil.dismissForegroundService(this);
+            AlarmUtil.cancelForegroundAlarm(this);
+        }
     }
 }

--- a/app/src/main/java/com/naccoro/wask/ui/main/MainActivity.java
+++ b/app/src/main/java/com/naccoro/wask/ui/main/MainActivity.java
@@ -63,7 +63,7 @@ public class MainActivity extends AppCompatActivity
         switch (view.getId()) {
             case R.id.button_change:
                 //교체하기 로직
-                presenter.changeMask(this);
+                presenter.changeMask();
                 break;
         }
     }
@@ -143,7 +143,7 @@ public class MainActivity extends AppCompatActivity
                 .setMessage(getString(R.string.dialog_cancel_replacement))
                 .addHorizontalButton(getString(R.string.dialog_cancel), (dialog, view) -> dialog.dismiss())
                 .addHorizontalButton(getString(R.string.dialog_ok), ((dialog, view) -> {
-                    presenter.cancelChanging(MainActivity.this);
+                    presenter.cancelChanging();
                     dialog.dismiss();
                 }))
                 .build()

--- a/app/src/main/java/com/naccoro/wask/ui/main/MainContract.java
+++ b/app/src/main/java/com/naccoro/wask/ui/main/MainContract.java
@@ -36,9 +36,9 @@ public interface MainContract {
 
         void clickCalendarButton();
 
-        void changeMask(Context context);
+        void changeMask();
 
-        void cancelChanging(Context context);
+        void cancelChanging();
 
     }
 

--- a/app/src/main/java/com/naccoro/wask/ui/main/MainContract.java
+++ b/app/src/main/java/com/naccoro/wask/ui/main/MainContract.java
@@ -1,7 +1,5 @@
 package com.naccoro.wask.ui.main;
 
-import android.content.Context;
-
 public interface MainContract {
 
     interface View {
@@ -26,6 +24,10 @@ public interface MainContract {
         void showNoReplaceData();
 
         void changeUsePeriodMessage(int period);
+
+        void setMaskReplaceNotification();
+
+        void showForegroundNotification(int period);
     }
 
     interface Presenter {
@@ -40,6 +42,7 @@ public interface MainContract {
 
         void cancelChanging();
 
+        void showForegroundNotification();
     }
 
 }

--- a/app/src/main/java/com/naccoro/wask/ui/main/MainPresenter.java
+++ b/app/src/main/java/com/naccoro/wask/ui/main/MainPresenter.java
@@ -76,7 +76,7 @@ public class MainPresenter implements MainContract.Presenter {
      * 사용자가 교체하기 버튼을 누를 경우 호출되는 함수
      */
     @Override
-    public void changeMask(Context context) {
+    public void changeMask() {
 
         if (!WaskApplication.isChanged) {
 //            checkIsFirstReplacement(getMaskPeriod());
@@ -90,7 +90,7 @@ public class MainPresenter implements MainContract.Presenter {
 
                     start();
 
-                    setMaskReplaceNotification(context);
+                    setMaskReplaceNotification(WaskApplication.getApplication());
                 }
 
                 @Override
@@ -107,14 +107,14 @@ public class MainPresenter implements MainContract.Presenter {
      * 교체 취소 다이얼로그에서 확인을 눌렀을 때 호출되는 함수
      */
     @Override
-    public void cancelChanging(Context context) {
+    public void cancelChanging() {
         replacementHistoryRepository.deleteToday();
         WaskApplication.isChanged = false;
 
         //메인화면 갱신
         start();
 
-        setMaskReplaceNotification(context);
+        setMaskReplaceNotification(WaskApplication.getApplication());
     }
 
     /**

--- a/app/src/main/java/com/naccoro/wask/ui/main/MainPresenter.java
+++ b/app/src/main/java/com/naccoro/wask/ui/main/MainPresenter.java
@@ -3,6 +3,7 @@ package com.naccoro.wask.ui.main;
 import android.util.Log;
 
 import com.naccoro.wask.WaskApplication;
+import com.naccoro.wask.notification.ServiceUtil;
 import com.naccoro.wask.preferences.SettingPreferenceManager;
 import com.naccoro.wask.replacement.repository.ReplacementHistoryRepository;
 import com.naccoro.wask.utils.DateUtils;

--- a/app/src/main/java/com/naccoro/wask/ui/main/MainPresenter.java
+++ b/app/src/main/java/com/naccoro/wask/ui/main/MainPresenter.java
@@ -1,17 +1,11 @@
 package com.naccoro.wask.ui.main;
 
-
-import android.content.Context;
-
-import com.naccoro.wask.WaskApplication;
-import com.naccoro.wask.notification.ServiceUtil;
-import com.naccoro.wask.preferences.SettingPreferenceManager;
-import com.naccoro.wask.utils.AlarmUtil;
-import com.naccoro.wask.utils.DateUtils;
-
 import android.util.Log;
 
+import com.naccoro.wask.WaskApplication;
+import com.naccoro.wask.preferences.SettingPreferenceManager;
 import com.naccoro.wask.replacement.repository.ReplacementHistoryRepository;
+import com.naccoro.wask.utils.DateUtils;
 
 public class MainPresenter implements MainContract.Presenter {
 
@@ -90,7 +84,7 @@ public class MainPresenter implements MainContract.Presenter {
 
                     start();
 
-                    setMaskReplaceNotification(WaskApplication.getApplication());
+                    setMaskReplaceNotification();
                 }
 
                 @Override
@@ -114,41 +108,24 @@ public class MainPresenter implements MainContract.Presenter {
         //메인화면 갱신
         start();
 
-        setMaskReplaceNotification(WaskApplication.getApplication());
+        setMaskReplaceNotification();
     }
 
     /**
      * Foreground  변경점을 반영한다.
      */
-    private void showForegroundNotification(Context context) {
-
+    public void showForegroundNotification() {
         if (SettingPreferenceManager.getIsShowNotificationBar()) {
             int period = getMaskPeriod();
-            if (period > 0) {
-                ServiceUtil.showForegroundService(context, period);
-                AlarmUtil.setForegroundAlarm(context);
-            } else {
-                ServiceUtil.dismissForegroundService(context);
-                AlarmUtil.cancelForegroundAlarm(context);
-            }
+            mainView.showForegroundNotification(period);
         }
     }
 
     /**
      * 등록되어 있는 알람을 종료하고 새로운 교체하기 알람을 등록한다.
      */
-    private void setMaskReplaceNotification(Context context) {
-        //기본 교체하기 알람이 있었다면 제거
-        if (AlarmUtil.isCycleAlarmExist(context)) {
-            AlarmUtil.cancelReplacementCycleAlarm(context);
-
-        //나중에 교체하기 알림 중이었다면 제거
-        } else if (AlarmUtil.isLaterAlarmExist(context)) {
-            AlarmUtil.cancelReplaceLaterAlarm(context);
-        }
-
-        showForegroundNotification(context);
-        AlarmUtil.setReplacementCycleAlarm(context);
+    private void setMaskReplaceNotification() {
+        mainView.setMaskReplaceNotification();
     }
 
     /**

--- a/app/src/main/java/com/naccoro/wask/utils/LanguageUtil.java
+++ b/app/src/main/java/com/naccoro/wask/utils/LanguageUtil.java
@@ -5,7 +5,6 @@ import android.content.res.Configuration;
 
 import com.naccoro.wask.R;
 import com.naccoro.wask.preferences.SettingPreferenceManager;
-import com.naccoro.wask.ui.splash.SplashActivity;
 
 import java.util.Locale;
 


### PR DESCRIPTION
~~부릉부릉 불꽃같은 PR입니다.~~

~민욱님 피드백 수용하여, `Presenter`에 존재하는 모든 `ActivityContext` 참조를 제거했습니다~

~이를 대신하여 `WaskApplication`에 있는 Application 객체를 받아와 사용했습니다.~

민욱님 피드백대로 `Presenter` 에서는 안드로이드 프레임워크의 종속성을 모두 제거해봤습니다.

유틸 클래스 호출이 대부분이었는데, 이를 액티비티에서 호출할 수 있도록 해보았습니다만

아직 긴가민가합니다. 이렇게 하는 게 맞을까요? 