### PR TITLE
refactor: 나중에 교체하기 설명 문구 변경(영어)

### DIFF
--- a/app/src/main/res/values-en-rUS/strings.xml
+++ b/app/src/main/res/values-en-rUS/strings.xml
@@ -13,7 +13,7 @@
     <string name="setting_push_alert_none">Silence</string>
     <string name="setting_language">Language</string>
     <string name="setting_language_label">Language</string>
-    <string name="setting_snooze_info">If you decide that It\'s okay to postpone the replacement, you can delay replacement by touching "Snooze" button.\nPlease select how many days you would like to postpone the notification</string>
+    <string name="setting_snooze_info">You may snooze the reminder if you decided to change your mask later.\nSimply tap the Snooze button, and we will notify you after the set days.</string>
 
     <string name="main_card_good">Use one mask a day</string>
     <string name="main_card_bad">Time to change your mask!</string>


### PR DESCRIPTION
검수를 또 받아왔습니다.
나중에 교체하기 설명 다이얼로그에 들어가는 내용입니다 !

# 수정 전
```
If you decide that It's okay to postpone the replacement, you can delay replacement by touching "Snooze" button.
Please select how many days you would like to postpone the notification
```

# 수정 후
```
You may snooze the reminder if you decided to change your mask later.
Simply tap the Snooze button, and we will notify you after the set days.
```