### PR TITLE
임시로 가로모드 이슈 대응

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,7 +20,8 @@
         <activity
             android:name=".setting.SettingActivity"/>
         <activity android:name=".ui.calendar.CalendarActivity" />
-        <activity android:name=".ui.main.MainActivity" />
+        <activity android:name=".ui.main.MainActivity"
+            android:screenOrientation="portrait"/>
         <activity
             android:name=".ui.splash.SplashActivity">
             <intent-filter>

--- a/app/src/main/res/layout/activity_setting.xml
+++ b/app/src/main/res/layout/activity_setting.xml
@@ -1,236 +1,241 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@android:color/white"
-    tools:context=".setting.SettingActivity">
-
-    <com.naccoro.wask.customview.WaskToolbar
-        android:id="@+id/wasktoolbar_setting"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    android:layout_height="match_parent">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/wasktoolbar_setting">
+        android:layout_height="wrap_content"
+        android:background="@android:color/white"
+        tools:context=".setting.SettingActivity">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/constraintlayout_replacementcyclealert"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="?android:attr/selectableItemBackground"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
-
-            <TextView
-                android:id="@+id/textview_replacementcyclealert_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="@dimen/margin_setting_left"
-                android:layout_marginTop="@dimen/margin_settingchild_top"
-                android:layout_marginBottom="@dimen/margin_settingchild_top"
-                android:letterSpacing="-0.02"
-                android:lineSpacingExtra="8sp"
-                android:text="@string/setting_replacement_cycle"
-                android:textColor="@color/waskGrayFont"
-                android:textSize="@dimen/textsize_setting_title"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <com.naccoro.wask.customview.PeriodPresenter
-                android:id="@+id/periodpresenter_replacementcyclealert_body"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/margin_settingchild_bottom"
-                android:letterSpacing="-0.02"
-                android:lineSpacingExtra="6sp"
-                android:textColor="@color/waskAccentFont"
-                android:textSize="@dimen/textsize_setting_body"
-                app:type="replacement_cycle"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="@+id/textview_replacementcyclealert_title"
-                app:layout_constraintTop_toBottomOf="@+id/textview_replacementcyclealert_title"
-                tools:text="3일" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/constraintlayout_replacelater"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="?android:attr/selectableItemBackground"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/constraintlayout_replacementcyclealert">
-
-            <TextView
-                android:id="@+id/textview_replacelater_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="@dimen/margin_setting_left"
-                android:layout_marginTop="@dimen/margin_settingchild_top"
-                android:layout_marginBottom="@dimen/margin_settingchild_top"
-                android:letterSpacing="-0.02"
-                android:lineSpacingExtra="8sp"
-                android:text="@string/setting_replace_later"
-                android:textColor="@color/waskGrayFont"
-                android:textSize="@dimen/textsize_setting_title"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <com.naccoro.wask.customview.PeriodPresenter
-                android:id="@+id/periodpresenter_replacelater_body"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/margin_settingchild_bottom"
-                android:letterSpacing="-0.02"
-                android:lineSpacingExtra="6sp"
-                android:textColor="@color/waskAccentFont"
-                android:textSize="@dimen/textsize_setting_body"
-                app:type="snooze_reminder"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="@+id/textview_replacelater_title"
-                app:layout_constraintTop_toBottomOf="@+id/textview_replacelater_title"
-                tools:text="1일" />
-
-            <ImageButton
-                android:id="@+id/imagebutton_replacelater_info"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:src="@drawable/ic_information"
-                android:background="@android:color/transparent"
-                app:layout_constraintTop_toTopOf="@id/textview_replacelater_title"
-                app:layout_constraintBottom_toBottomOf="@id/textview_replacelater_title"
-                app:layout_constraintStart_toEndOf="@+id/textview_replacelater_title"
-                android:padding="@dimen/padding_settinginfo"/>
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/constraintlayout_pushalert"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="?android:attr/selectableItemBackground"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/constraintlayout_replacelater">
-
-            <TextView
-                android:id="@+id/textview_pushalert_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="@dimen/margin_setting_left"
-                android:layout_marginTop="@dimen/margin_settingchild_top"
-                android:letterSpacing="-0.02"
-                android:lineSpacingExtra="8sp"
-                android:text="@string/setting_push_alert"
-                android:textColor="@color/waskGrayFont"
-                android:textSize="@dimen/textsize_setting_title"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <TextView
-                android:id="@+id/textview_pushalert_body"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/margin_settingchild_bottom"
-                android:letterSpacing="-0.02"
-                android:lineSpacingExtra="6sp"
-                android:textColor="@color/waskAccentFont"
-                android:textSize="@dimen/textsize_setting_body"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="@+id/textview_pushalert_title"
-                app:layout_constraintTop_toBottomOf="@+id/textview_pushalert_title"
-                tools:text="소리+진동" />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/constraintlayout_langause"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="?android:attr/selectableItemBackground"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/constraintlayout_pushalert">
-
-            <TextView
-                android:id="@+id/textview_langause_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="@dimen/margin_setting_left"
-                android:layout_marginTop="@dimen/margin_settingchild_top"
-                android:letterSpacing="-0.02"
-                android:lineSpacingExtra="8sp"
-                android:text="@string/setting_language_label"
-                android:textColor="@color/waskGrayFont"
-                android:textSize="@dimen/textsize_setting_title"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <TextView
-                android:id="@+id/textview_langause_body"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/margin_settingchild_bottom"
-                android:letterSpacing="-0.02"
-                android:lineSpacingExtra="6sp"
-                android:textColor="@color/waskAccentFont"
-                android:textSize="@dimen/textsize_setting_body"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="@+id/textview_langause_title"
-                app:layout_constraintTop_toBottomOf="@+id/textview_langause_title"
-                tools:text="한국어" />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/constraintlayout_foregroundalert"
+        <com.naccoro.wask.customview.WaskToolbar
+            android:id="@+id/wasktoolbar_setting"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/constraintlayout_langause">
+            app:layout_constraintTop_toTopOf="parent" />
 
-            <TextView
-                android:id="@+id/textview_foregroundalert_title"
-                android:layout_width="0dp"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/wasktoolbar_setting">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/constraintlayout_replacementcyclealert"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginLeft="@dimen/margin_setting_left"
-                android:layout_marginRight="@dimen/margin_setting_left"
-                android:layout_marginTop="@dimen/margin_settingchild_top"
-                android:layout_marginBottom="@dimen/margin_settingchild_bottom"
-                android:letterSpacing="-0.02"
-                android:text="@string/setting_foreground_alert"
-                android:textColor="@color/waskGrayFont"
-                android:textSize="@dimen/textsize_setting_title"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toStartOf="@+id/switch_foregroundalert"
-                app:layout_constraintHorizontal_bias="0.0"
+                android:background="?android:attr/selectableItemBackground"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toTopOf="parent">
 
-            <androidx.appcompat.widget.SwitchCompat
-                android:id="@+id/switch_foregroundalert"
-                style="@style/SwitchThumb"
-                android:layout_width="wrap_content"
+                <TextView
+                    android:id="@+id/textview_replacementcyclealert_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="@dimen/margin_setting_left"
+                    android:layout_marginTop="@dimen/margin_settingchild_top"
+                    android:layout_marginBottom="@dimen/margin_settingchild_top"
+                    android:letterSpacing="-0.02"
+                    android:lineSpacingExtra="8sp"
+                    android:text="@string/setting_replacement_cycle"
+                    android:textColor="@color/waskGrayFont"
+                    android:textSize="@dimen/textsize_setting_title"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <com.naccoro.wask.customview.PeriodPresenter
+                    android:id="@+id/periodpresenter_replacementcyclealert_body"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/margin_settingchild_bottom"
+                    android:letterSpacing="-0.02"
+                    android:lineSpacingExtra="6sp"
+                    android:textColor="@color/waskAccentFont"
+                    android:textSize="@dimen/textsize_setting_body"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="@+id/textview_replacementcyclealert_title"
+                    app:layout_constraintTop_toBottomOf="@+id/textview_replacementcyclealert_title"
+                    app:type="replacement_cycle"
+                    tools:text="3일" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/constraintlayout_replacelater"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginEnd="@dimen/margin_settingchild_top"
-                android:track="@drawable/selector_foregroundalert_switch"
-                app:layout_constraintBottom_toBottomOf="@+id/textview_foregroundalert_title"
+                android:background="?android:attr/selectableItemBackground"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/textview_foregroundalert_title" />
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/constraintlayout_replacementcyclealert">
+
+                <TextView
+                    android:id="@+id/textview_replacelater_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="@dimen/margin_setting_left"
+                    android:layout_marginTop="@dimen/margin_settingchild_top"
+                    android:layout_marginBottom="@dimen/margin_settingchild_top"
+                    android:letterSpacing="-0.02"
+                    android:lineSpacingExtra="8sp"
+                    android:text="@string/setting_replace_later"
+                    android:textColor="@color/waskGrayFont"
+                    android:textSize="@dimen/textsize_setting_title"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <com.naccoro.wask.customview.PeriodPresenter
+                    android:id="@+id/periodpresenter_replacelater_body"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/margin_settingchild_bottom"
+                    android:letterSpacing="-0.02"
+                    android:lineSpacingExtra="6sp"
+                    android:textColor="@color/waskAccentFont"
+                    android:textSize="@dimen/textsize_setting_body"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="@+id/textview_replacelater_title"
+                    app:layout_constraintTop_toBottomOf="@+id/textview_replacelater_title"
+                    app:type="snooze_reminder"
+                    tools:text="1일" />
+
+                <ImageButton
+                    android:id="@+id/imagebutton_replacelater_info"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@android:color/transparent"
+                    android:padding="@dimen/padding_settinginfo"
+                    android:src="@drawable/ic_information"
+                    app:layout_constraintBottom_toBottomOf="@id/textview_replacelater_title"
+                    app:layout_constraintStart_toEndOf="@+id/textview_replacelater_title"
+                    app:layout_constraintTop_toTopOf="@id/textview_replacelater_title" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/constraintlayout_pushalert"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?android:attr/selectableItemBackground"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/constraintlayout_replacelater">
+
+                <TextView
+                    android:id="@+id/textview_pushalert_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="@dimen/margin_setting_left"
+                    android:layout_marginTop="@dimen/margin_settingchild_top"
+                    android:letterSpacing="-0.02"
+                    android:lineSpacingExtra="8sp"
+                    android:text="@string/setting_push_alert"
+                    android:textColor="@color/waskGrayFont"
+                    android:textSize="@dimen/textsize_setting_title"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/textview_pushalert_body"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/margin_settingchild_bottom"
+                    android:letterSpacing="-0.02"
+                    android:lineSpacingExtra="6sp"
+                    android:textColor="@color/waskAccentFont"
+                    android:textSize="@dimen/textsize_setting_body"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="@+id/textview_pushalert_title"
+                    app:layout_constraintTop_toBottomOf="@+id/textview_pushalert_title"
+                    tools:text="소리+진동" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/constraintlayout_langause"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?android:attr/selectableItemBackground"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/constraintlayout_pushalert">
+
+                <TextView
+                    android:id="@+id/textview_langause_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="@dimen/margin_setting_left"
+                    android:layout_marginTop="@dimen/margin_settingchild_top"
+                    android:letterSpacing="-0.02"
+                    android:lineSpacingExtra="8sp"
+                    android:text="@string/setting_language_label"
+                    android:textColor="@color/waskGrayFont"
+                    android:textSize="@dimen/textsize_setting_title"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/textview_langause_body"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/margin_settingchild_bottom"
+                    android:letterSpacing="-0.02"
+                    android:lineSpacingExtra="6sp"
+                    android:textColor="@color/waskAccentFont"
+                    android:textSize="@dimen/textsize_setting_body"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="@+id/textview_langause_title"
+                    app:layout_constraintTop_toBottomOf="@+id/textview_langause_title"
+                    tools:text="한국어" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/constraintlayout_foregroundalert"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/constraintlayout_langause">
+
+                <TextView
+                    android:id="@+id/textview_foregroundalert_title"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="@dimen/margin_setting_left"
+                    android:layout_marginTop="@dimen/margin_settingchild_top"
+                    android:layout_marginRight="@dimen/margin_setting_left"
+                    android:layout_marginBottom="@dimen/margin_settingchild_bottom"
+                    android:letterSpacing="-0.02"
+                    android:text="@string/setting_foreground_alert"
+                    android:textColor="@color/waskGrayFont"
+                    android:textSize="@dimen/textsize_setting_title"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@+id/switch_foregroundalert"
+                    app:layout_constraintHorizontal_bias="0.0"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/switch_foregroundalert"
+                    style="@style/SwitchThumb"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="@dimen/margin_settingchild_top"
+                    android:track="@drawable/selector_foregroundalert_switch"
+                    app:layout_constraintBottom_toBottomOf="@+id/textview_foregroundalert_title"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="@+id/textview_foregroundalert_title" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>


### PR DESCRIPTION
issue #111 

가로모드에 대응하는 xml을 만드는 것을 `ice box`에 옮기지만 
출시되는 앱인데 `MainActivity` 화면은 가로모드를 막아 놓아야 할 듯 해서 적용해 보았습니다.

`MainActivity`는 현재 `세로모드`만 가능하게 해두었고, 나머지 Calendar 화면, Setting 화면은 아직은 괜찮은 듯 합니다.
Calendar 화면, Setting 화면은 `가로 모드`,`세로 모드` 둘 다 가능하고 Setting은 기존에 스크롤이 안나와 화면이 짤렸기 때문에 스크롤이 가능하게 끔 `ScrollView`를 추가 했습니다.