### PR TITLE
Feature/restart foreground service

### DIFF
--- a/app/src/main/java/com/naccoro/wask/notification/WaskService.java
+++ b/app/src/main/java/com/naccoro/wask/notification/WaskService.java
@@ -11,6 +11,7 @@ import androidx.core.app.NotificationCompat;
 
 import com.naccoro.wask.R;
 import com.naccoro.wask.WaskApplication;
+import com.naccoro.wask.preferences.SettingPreferenceManager;
 import com.naccoro.wask.ui.main.MainActivity;
 
 public class WaskService extends Service {
@@ -52,10 +53,27 @@ public class WaskService extends Service {
         RemoteViews contentView = new RemoteViews(getPackageName(), R.layout.notification_foreground);
         contentView.setImageViewResource(R.id.imageview_notification_logo, R.drawable.ic_notification_logo);
         String content;
-        if (maskPeriod == 1) {
-            content = String.format(getString(R.string.notification_alert_singular), maskPeriod);
-        } else {
-            content = String.format(getString(R.string.notification_alert_plural), maskPeriod);
+        //Todo: Service 내에서는 getString이 설정된 Locale에 따라가지 않고 디바이스 설정을 무조건 따라감.
+        //Todo: 우선 배포를 위해 아래와 같이 언어 설정 값에 따라 명시적으로 문자열을 강제 변경하였으나 개선이 필요.
+        switch (SettingPreferenceManager.getLanguage()) {
+            default: //Default
+                if (maskPeriod == 1) {
+                    content = String.format(getString(R.string.notification_alert_singular), maskPeriod);
+                } else {
+                    content = String.format(getString(R.string.notification_alert_plural), maskPeriod);
+                }
+                break;
+            case 1: //Korean
+                content = String.format(getString(R.string.notification_alert_singular_kr), maskPeriod);
+                break;
+
+            case 2: //English
+                if (maskPeriod == 1) {
+                    content = String.format(getString(R.string.notification_alert_singular_en), maskPeriod);
+                } else {
+                    content = String.format(getString(R.string.notification_alert_plural_en), maskPeriod);
+                }
+                break;
         }
         contentView.setTextViewText(R.id.textview_notification_content, content);
 

--- a/app/src/main/java/com/naccoro/wask/setting/SettingActivity.java
+++ b/app/src/main/java/com/naccoro/wask/setting/SettingActivity.java
@@ -232,6 +232,7 @@ public class SettingActivity extends AppCompatActivity
 
     @Override
     public void refresh() {
+        ServiceUtil.dismissForegroundService(this);
         Intent intent = getBaseContext().getPackageManager().getLaunchIntentForPackage(getBaseContext().getPackageName());
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,6 +95,13 @@
     <string name="notification_alert_singular">마스크를 %d일 째 사용중입니다</string>
     <string name="notification_alert_plural">@string/notification_alert_singular</string>
 
+
+    <string name="notification_alert_singular_kr" translatable="false">마스크를 %d일 째 사용중입니다</string>
+
+    <string name="notification_alert_singular_en" translatable="false">You\'ve been wearing your mask for %d day</string>
+    <string name="notification_alert_plural_en" translatable="false">You\'ve been wearing your mask for %d days</string>
+
+
     <string name="period_prefix_snooze"></string>
     <string name="period_prefix_cycle"></string>
     <string name="period_suffix_singular"></string>


### PR DESCRIPTION
# 개요
앱 내 자체적으로 언어를 변경할 수 있도록 하였으나, `ForegroundService`의 `Notification`은 앱 내 설정된 언어를 따라가지 않고 디바이스의 언어 설명을 맹목적으로 따라가는 현상을 발견하였습니다. `Notification`에서도 앱 내 언어 설정에 맞춰 문자열을 표기할 수 있도록 별도의 처리를 해주었습니다.

# 해결 방법
우선은 앱 내 언어를 변경할 때, `Notification` 갱신을 위해 이를 서비스를 종료하였습니다. 그리고 서비스를 다시 시작할 때 `Notification`을 초기화하는 과정에서 `SettingPreferenceManager`로 부터 설정된 언어 값을 가져오고, 이를 `switch` 문에서 분기하여 각 언어에 맞게 `명시적`으로 문자열을 적용해주었습니다.

# 삽질 기록
`Notification` 의 채널이 한 번 할당되면 채널에 대한 속성 변경이 반영되지 않은 점을 기억하여, 혹시 문자열이 변경되지 않은 것도 이와 같은 원인일까 생각하여 채널을 제거하고 재 할당하는 등 여러가지 시도를 해봤지만 해결되지 않았습니다. 잘 생각해보면 저희는 이미 매일 자정마다 마스크 사용 일자를 갱신하기 위해서 `Notification` 을 재시작합니다. 이 때 채널을 삭제하지 않아도 문자열이 정상적으로 변경되는 걸 보면, 채널의 재할당 부는 원인이 아닌것이 맞습니다.

# 개선필요
구글링을 해보아도 저희와 같은 문제를 겪고 있는 글을 찾기 어려웠습니다. 그리고 별도의 논리적인 문제가 아니라 프레임워크 내에서 언어 설정에 따라 strings.xml을 매핑해주는 과정에서 문제가 있는 것 같은데 저희 수준에서 이를 깊에 파고들어 원인을 파악하기는 쉬운 일이 아니라 판단하였습니다.
지금도 이미 배포가 예정보다 늦어진 상황이라 우선은 코드가 지저분하더라도 이렇게 마무리 해보려고 합니다. 개선을 위한 `Todo` 주석은 남겨두었습니다 !