### PR TITLE
빌드에러 - AppCompat 버전변경

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'com.google.android.material:material:1.1.0'


### PR DESCRIPTION
다음과 같은 에러로그가 발생하며 빌드 실패!
```
2021-05-18 18:37:41.975 29423-29423/com.naccoro.wask E/TypefaceCompatApi26Impl: Unable to collect necessary methods for class java.lang.NoSuchMethodException
    java.lang.NoSuchMethodException: android.graphics.FontFamily.<init> []
...
2021-05-18 18:37:41.977 29423-29423/com.naccoro.wask E/AndroidRuntime: Caused by: android.view.InflateException: Binary XML file line #30 in com.naccoro.wask:layout/layout_wask_toolbar: Error inflating class TextView
    Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Object java.lang.reflect.Constructor.newInstance(java.lang.Object[])' on a null object reference
```
`NoSuchmethodErrors`가 발생합니다.
-> 클래스 정의가 비호환적으로 변경된 경우 런타임시 발생한다고 합니다.

라이브러리의 버전이 변경될 때, `Breaking Change`를 포함하는 경우에 발생하는 경우에 발생할 수 있다고 합니다. 위의 에러를 통해 `FontFamily`문제임을 알았습니다!

글꼴 지정은 `AppCompat`라이브러리를 통해 지원됩니다.
<img src="https://user-images.githubusercontent.com/37680108/118641045-a27eae80-b814-11eb-8128-1d13ea6307e6.png" width="550">

현재 안정화 버전인 **1.2.0**으로 변경했습니다.
<img src="https://user-images.githubusercontent.com/37680108/118641410-1456f800-b815-11eb-9050-047f476ebafa.png" width="400">

해결됨! 

### 그런데 말입니다
- `AppCompat-1.1.0` 버전이 `Breaking Change`를 포함하는지는 알 수 없었습니다. (찝찝)
- 아무튼 `DI` 적용이 필요해 보이네요! (잘모름)