### PR TITLE
chore: update versionCode

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
         applicationId "com.naccoro.wask"
         minSdkVersion 23
         targetSdkVersion 30
-        versionCode 9
+        versionCode 10
         versionName "1.2.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/37680108/123030394-b756ef00-d41d-11eb-8ae7-365713e3e364.png)

`versionCode 9` 로 aab파일을 생성하고 출시하려 했으나,
위 에러가 발생하여 축소, 난독화, 최적화를 사용하여 다시 aab파일을 만들었습니다.

그런데 이미 Play에 9버전이 올라가 있으므로 **10버전**으로 올렸습니다!

#### (참고) 축소, 난독화, 최적화
```gradle
android {
    buildTypes {
        release {
            minifyEnabled true
            shrinkResources true
        }
    }
    ...
}
```
앱의 최종 버전을 만들 때만 사용 설정!
> 왜냐하면 위 설정으로 인해 프로젝트 빌드 시간이 늘어나고, 버그 발생 가능성이 있다고 합니다.

참조 : https://developer.android.com/studio/build/shrink-code#enable